### PR TITLE
新增 CI：pytest 矩阵、套件清单校验、lint 与类型检查

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Gates the product's own promises: the suite passes, and the shipped tree
+  # matches the hashes in suite-manifest.json. The manifest check is separate
+  # because a stale manifest tells every installer the suite is tampered, which
+  # is exactly the failure that reached a pull request before this workflow
+  # existed.
+  test:
+    name: tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --disable-pip-version-check pytest==9.1.1
+      - name: pytest
+        run: python -m pytest -q
+      - name: suite manifest matches the shipped tree
+        run: python tools/verify_suite.py skills/short-drama
+
+  # Tool versions are pinned on purpose. This repository has no dependency
+  # manifest, so an unpinned `pip install ruff` turns main red the next time
+  # ruff changes its default rule set — with nobody having touched the code.
+  # Bumping these is a deliberate pull request, not a surprise.
+  lint:
+    name: lint and types
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m pip install --disable-pip-version-check ruff==0.15.11 mypy==2.3.0
+      - name: ruff
+        run: ruff check skills tests tools
+      - name: mypy
+        run: >
+          mypy skills/short-drama/scripts/project_tool.py
+          skills/short-drama/scripts/dashboard_server.py
+          --ignore-missing-imports
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: dashboard script parses
+        run: node --check skills/short-drama/assets/dashboard/app.js


### PR DESCRIPTION
## 为什么

仓库此前没有任何 CI。PR #7 的分支上曾同时存在 **9 个失败测试**和 **6 个对不上的
`suite-manifest.json` 哈希**，一路开到评审阶段都没有任何东西拦住。后者的后果是面向
安装者的：按 `references/runtime-preflight.md` 第一步执行 `suite_verify.py` 的人，
会被告知这套技能已被篡改、应当停止。

## 内容

- **tests**：Python 3.10 / 3.11 / 3.12 / 3.13 上跑 `pytest`，再单独跑
  `tools/verify_suite.py` 确认 shipped tree 与清单哈希一致。清单单列一步，因为它
  坏掉时的表现和普通测试失败完全不同。
- **lint**：`ruff`、`mypy`、`node --check`。

## 工具版本全部钉死

这一点是有意的。仓库没有 `pyproject.toml`、`requirements.txt` 或任何 ruff 配置，
所以不钉版本的话，下一次 ruff 调整默认规则集就会让 main 变红，而没有人动过代码。

实测：同一份代码，`ruff 0.15.11` 全绿，`ruff 0.16.1` 报 **90 处**
（TRY004 ×25、I001 ×22、SIM117 ×18、EXE001 ×8、B023 ×6、BLE001 ×4 等）。
升级工具版本应该是一次有意的 PR，而不是某天早上的意外。

钉的三个版本都在**干净 clone + 全新 venv** 里实跑验证过：
`pytest 9.1.1`、`ruff 0.15.11`、`mypy 2.3.0`。

## 关于干净 checkout 的两点

- 干净环境下是 `365 passed, 9 skipped`（本地是 366 passed）。跳过的 9 个依赖
  `tests/local-terms.txt`——该文件按设计不入库，`load_private_terms` 在缺失且未设
  `DRAMA_REQUIRE_PRIVATE_RELEASE_GATE=1` 时返回空集合，属于预期行为。
- `.github/` 不进 `suite-manifest.json`（清单只扫 `skills/`），本 PR 不影响任何哈希。

## 后续（不在本 PR 内）

`ruff 0.16` 报的 90 处里，`B023 function-uses-loop-variable` 有 6 处，属于真实缺陷
类别，值得单独开一个 PR 处理，然后再升 ruff 版本钉子。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXrcfrrfKdFV3D5c7vPESu