### PR TITLE
docs: remove redundant dashboard description paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,6 @@ https://github.com/user-attachments/assets/ae88b444-06e5-4964-856c-91e619020f12
 /short-drama dashboard
 ```
 
-创作台仅支持 macOS/Linux 本机运行。界面只有一个页面：左侧是按项目和剧集整理的
-内容目录，右侧始终直接显示当前正文；打开项目后会自动载入剧本，不再切页或弹出浮层。
-待办与导出只在正文下方给出简短提示，工程文件、路径和生命周期由系统内部维护。
-
 <img src="docs/assets/dashboard-zh.png" alt="短剧创作台：左侧内容目录，右侧剧本正文" width="680">
 
 ## 致谢


### PR DESCRIPTION
Removes the paragraph in README.md describing the dashboard UI (platform support, single-page layout, todo/export hints). The screenshot right below it already conveys the layout, so the prose was redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)