### PR TITLE
release: prepare v0.3.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
 
 ## [未发布]
 
+## [0.3.0-rc.1] - 2026-08-13
+
+首个 0.3.0 发布候选：新增原著分析、多集整稿断点接入与中文创作台，补齐输出语言、
+Look Development、生产观察校准和更严格的项目生命周期，同时修复 Windows 安装校验。
+
 ### 新增
 
 - **多集完整剧本按 Agent 判断切片并可断点续跑（修复 #27）**。`$short-drama-develop`
@@ -478,6 +483,7 @@ image-prompts / storyboard / video-prompts / review。
 fresh-agent 双臂盲测、独立 reviewer verdict 与 protected-release gate 三项未完成，
 由维护者知情后放行；相应记录以 `hold` 而非 `promotion` 留在仓库外的受控工作区。
 
-[未发布]: https://github.com/worldwonderer/drama-skills/compare/v0.2.0...HEAD
+[未发布]: https://github.com/worldwonderer/drama-skills/compare/v0.3.0-rc.1...HEAD
+[0.3.0-rc.1]: https://github.com/worldwonderer/drama-skills/compare/v0.2.0...v0.3.0-rc.1
 [0.2.0]: https://github.com/worldwonderer/drama-skills/releases/tag/v0.2.0
 [0.1.0]: https://github.com/worldwonderer/drama-skills/releases/tag/v0.1.0

--- a/skills/short-drama-assets/suite-ref.json
+++ b/skills/short-drama-assets/suite-ref.json
@@ -1,1 +1,1 @@
-{"suite":"short-drama-suite","suite_version":"0.2.0","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"410b6e325dd1db36ad70bf0af9fd5422ee7705872ac71bd84ac17c89a95645f2"}
+{"suite":"short-drama-suite","suite_version":"0.3.0-rc.1","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"c8e2f509e841282fbb4c742aad954108c199ec6ca96c30ed40beee17c56a2400"}

--- a/skills/short-drama-develop/suite-ref.json
+++ b/skills/short-drama-develop/suite-ref.json
@@ -1,1 +1,1 @@
-{"suite":"short-drama-suite","suite_version":"0.2.0","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"410b6e325dd1db36ad70bf0af9fd5422ee7705872ac71bd84ac17c89a95645f2"}
+{"suite":"short-drama-suite","suite_version":"0.3.0-rc.1","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"c8e2f509e841282fbb4c742aad954108c199ec6ca96c30ed40beee17c56a2400"}

--- a/skills/short-drama-image-prompts/suite-ref.json
+++ b/skills/short-drama-image-prompts/suite-ref.json
@@ -1,1 +1,1 @@
-{"suite":"short-drama-suite","suite_version":"0.2.0","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"410b6e325dd1db36ad70bf0af9fd5422ee7705872ac71bd84ac17c89a95645f2"}
+{"suite":"short-drama-suite","suite_version":"0.3.0-rc.1","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"c8e2f509e841282fbb4c742aad954108c199ec6ca96c30ed40beee17c56a2400"}

--- a/skills/short-drama-novel-analyze/suite-ref.json
+++ b/skills/short-drama-novel-analyze/suite-ref.json
@@ -1,1 +1,1 @@
-{"suite":"short-drama-suite","suite_version":"0.2.0","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"410b6e325dd1db36ad70bf0af9fd5422ee7705872ac71bd84ac17c89a95645f2"}
+{"suite":"short-drama-suite","suite_version":"0.3.0-rc.1","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"c8e2f509e841282fbb4c742aad954108c199ec6ca96c30ed40beee17c56a2400"}

--- a/skills/short-drama-review/suite-ref.json
+++ b/skills/short-drama-review/suite-ref.json
@@ -1,1 +1,1 @@
-{"suite":"short-drama-suite","suite_version":"0.2.0","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"410b6e325dd1db36ad70bf0af9fd5422ee7705872ac71bd84ac17c89a95645f2"}
+{"suite":"short-drama-suite","suite_version":"0.3.0-rc.1","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"c8e2f509e841282fbb4c742aad954108c199ec6ca96c30ed40beee17c56a2400"}

--- a/skills/short-drama-storyboard/suite-ref.json
+++ b/skills/short-drama-storyboard/suite-ref.json
@@ -1,1 +1,1 @@
-{"suite":"short-drama-suite","suite_version":"0.2.0","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"410b6e325dd1db36ad70bf0af9fd5422ee7705872ac71bd84ac17c89a95645f2"}
+{"suite":"short-drama-suite","suite_version":"0.3.0-rc.1","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"c8e2f509e841282fbb4c742aad954108c199ec6ca96c30ed40beee17c56a2400"}

--- a/skills/short-drama-video-prompts/suite-ref.json
+++ b/skills/short-drama-video-prompts/suite-ref.json
@@ -1,1 +1,1 @@
-{"suite":"short-drama-suite","suite_version":"0.2.0","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"410b6e325dd1db36ad70bf0af9fd5422ee7705872ac71bd84ac17c89a95645f2"}
+{"suite":"short-drama-suite","suite_version":"0.3.0-rc.1","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"c8e2f509e841282fbb4c742aad954108c199ec6ca96c30ed40beee17c56a2400"}

--- a/skills/short-drama-write/suite-ref.json
+++ b/skills/short-drama-write/suite-ref.json
@@ -1,1 +1,1 @@
-{"suite":"short-drama-suite","suite_version":"0.2.0","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"410b6e325dd1db36ad70bf0af9fd5422ee7705872ac71bd84ac17c89a95645f2"}
+{"suite":"short-drama-suite","suite_version":"0.3.0-rc.1","contract_version":"1.0.0-draft","core_skill":"short-drama","core_manifest":"../short-drama/suite-manifest.json","recipe_version":"1.0.0-draft","core_manifest_sha256":"c8e2f509e841282fbb4c742aad954108c199ec6ca96c30ed40beee17c56a2400"}

--- a/skills/short-drama/suite-manifest.json
+++ b/skills/short-drama/suite-manifest.json
@@ -185,7 +185,7 @@
   ],
   "recipe_version": "1.0.0-draft",
   "suite": "short-drama-suite",
-  "suite_version": "0.2.0",
+  "suite_version": "0.3.0-rc.1",
   "trust_boundary": {
     "host_text_inference": true,
     "media_generation": false,


### PR DESCRIPTION
## Summary

Prepare the first release candidate for the 0.3.0 line.

- bump the public suite from `0.2.0` to `0.3.0-rc.1`
- refresh all eight child `suite-ref.json` pins
- cut the accumulated unreleased changelog into a dated RC section

## Release readiness

- protected release gate passed in fail-closed mode with an externally injected maintainer terms file; no private terms or findings were printed
- `python3 -B -m unittest discover -s tests` — 348 passed
- `ruff check skills tests tools`
- `mypy` for project tool, dashboard server, and episode intake
- `node --check` for the dashboard application
- suite verification — 169 files / 9 skills
- independent release verifier: metadata/version/changelog approved; exact candidate CI remains the merge gate

After this PR is green and merged, `v0.3.0-rc.1` will be annotated at the merged main commit and published as a GitHub prerelease.
