### PR TITLE
release: v0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
           skills/short-drama-produce/scripts/provider_adapters.py
           skills/short-drama-review/scripts/review_check.py
           skills/short-drama-video-prompts/scripts/music_spec_check.py
+          evaluations/content_quality_gate.py
           --ignore-missing-imports
       - uses: actions/setup-node@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,30 +9,54 @@
 
 ## [未发布]
 
+## [0.6.0] - 2026-08-23
+
+本版把默认创作路径从结构化流水线改为 creator-first 五文档，并重整短剧写作规则的
+启用方式：工具与审查只在题面确实承诺某种叙事机制时应用对应约束，详细 knowhow 仍按
+具体问题提供。版本同时补充漫剧关键帧词表与端到端创作指引，并让 Dashboard 原生识别
+新的文档布局。
+
+这是一次**破坏性版本升级**。creator-first 不是旧结构化项目的就地升级格式；旧、新两套
+创作真相不得在同一项目根目录并排维护。
+
 ### 变更
-
-**短剧写作专项规则改为按机制启用，并扩大跨题材质量验证**。SCR-13（艰难选择）、SCR-14
-（争议证据）、SCR-16（字面精确死线）与 SCR-17（有限单位完成边界）只在剧本实际承诺对应机制时
-审查；事务性角色、安静收束、蒙太奇/主观时间、故意保留悬疑不再被迫改成统一模板。顶层 Skill 改为
-输入优先的规则选择器，详细 knowhow 完整保留在按需参考中，并新增不发明精确数字/记录、验证停止条件
-和连续性标签不能证明镜头外负面事实的边界。内容门禁扩为 16 个题材：12 个已见案例归 development，
-另加 4 个冻结后只运行一次的 holdout 与第 4 个负对照；每案例、每 arm 固定 3 次独立创作，再由
-Codex/Kimi A/B 换位产生 12 份盲评报告。两 arm 必须在只含各自写作 Skill bundle 的同构净化工作区
-生成，judge 必须在只接收本次 prompt、且不物化评测文件的空工作区运行；收据分别绑定 `source-bundle-only` 与 `prompt-only`
-策略，拒绝完整 worktree、manifest 和历史报告混杂。v5 门禁先按 replicate 再按案例等权聚合，通过 manifest 外
-的维护者可信 seal 绑定公开 corpus、源码 bundle、基线提交、中性提示词、量表、模型配置、私有泄漏
-词表和调用收据，拒绝缺失/复用 replicate、重复题面/作品，并单独检查模型家族、A/B 位置、评分维度、
-题面忠实度、题材适配和过拟合标签。
-
-**贡献测试不得用纯字符串包含断言钉死文案**。规则契约应结构化验证，工具用输入/输出夹具证明行为，
-内容判断使用隔离实跑与盲评；泄漏扫描器的测试验证扫描边界，不把当前文档的一句话当成功条件。
 
 **公开创作流程改为 creator-first 五文档**。普通创作只按需维护 `剧本.md`、`视觉设定.md`、
 `分镜.md`、`图片提示词.md` 和 `视频提示词.md`；场次/资产/镜头批次自动续跑，不再为每批生成
-JSON/JSONL、索引、指纹、覆盖表或 QA 记录。审查结果改为创作者可读的 Markdown，生产前显式确认不变。
+JSON/JSONL、索引、指纹、覆盖表或 QA 记录。用户点名整集或整阶段时一次完成，也可从任一创作
+阶段直接进入，不为流程完整补造名义上游。审查结果改为创作者可读的 Markdown；外部媒体生产仍须
+经过准备、显式确认和执行三个阶段。
 
 **Dashboard 原生识别 creator-first 五文档**。中文文件名会进入正确内容分组，默认打开 `剧本.md`，
 并从可见文档和媒体推导本集进度。
+
+**短剧写作专项规则改为按机制启用**。SCR-13（艰难选择）、SCR-14（争议证据）、SCR-16
+（字面精确死线）与 SCR-17（有限单位完成边界）只在剧本实际承诺对应机制时审查；事务性角色、
+安静收束、蒙太奇或主观时间，以及故意保留的悬疑，不再被迫改成同一套模板。顶层 Skill 改为
+输入优先的规则选择器，详细 knowhow 完整保留在按需参考中，并补充不发明精确数字、记录、资源
+与程序，证据验证停止条件，以及连续性标签不能证明镜头外负面事实等边界。
+
+**内容质量门禁扩为跨题材、可复现的隔离 A/B 协议**。公开 corpus 区分可迭代的 development、
+冻结后只运行一次的 holdout 与负对照；每个案例、每个 arm 固定执行 3 次独立创作，再由两个
+模型家族进行 A/B 换位盲评。生成端只接收各自的写作 Skill bundle，评审端只接收本次 prompt；
+收据分别绑定 `source-bundle-only` 与 `prompt-only` 策略。schema v5 按 replicate、案例逐级
+等权聚合，并通过仓库外的维护者可信 seal 绑定 corpus、源码 bundle、基线提交、中性提示词、
+量表、模型配置、私有泄漏词表与调用收据。
+
+**贡献测试不得用纯字符串包含断言钉死文案**。规则契约应结构化验证，工具用输入/输出夹具证明
+行为，内容判断使用隔离实跑与盲评；泄漏扫描器的测试验证扫描边界，不把当前文档的一句话当作
+成功条件。
+
+### 迁移与回滚
+
+- **v0.5 在途项目继续锁定 `v0.5.0`**。不要在原项目根目录直接切换到 creator-first，
+  也不要把两套产物并排放置后交替调用不同版本。
+- **升级时新建 creator-first 项目根目录**。逐集人工转移并重新确认 `剧本.md`、
+  `视觉设定.md`、`分镜.md`、`图片提示词.md` 和 `视频提示词.md` 这五份创作真相；不要把
+  旧 JSON/JSONL 自动转换后直接视为已确认内容。
+- **旧结构化产物、生产记录与审计证据只读保留**。它们用于追溯既有生产，不再作为新项目
+  的并行真相来源。需要回滚时，回到原 v0.5 项目根目录并继续锁定 `v0.5.0`；不要把新五文档
+  反向写回旧结构化目录。
 
 ### 新增
 
@@ -45,6 +69,12 @@ JSON/JSONL、索引、指纹、覆盖表或 QA 记录。审查结果改为创作
 **docs 新增《漫剧 Creator-first 全流程》**。`docs/comic-drama-workflow.md` 把十个技能串成一条
 可照做的漫剧产线路径：从初始化与视觉方向，到剧本、资产、图片提示词、分镜关键帧、视频
 提示词、确认后生产、审查与文本交付，含每步命令、产物位置与常见卡点。
+
+### 修复
+
+**修正随发布 Markdown 中无法闭合的粗体标记**。将粗体段落末尾标点移到标记之外，避免
+句末标点紧邻闭合标记的写法在 GitHub 按字面显示星号；新增 CommonMark 形状检查覆盖
+随发布文档，固定评估产物保持原样。
 
 ## [0.5.0] - 2026-08-19
 
@@ -1097,7 +1127,12 @@ image-prompts / storyboard / video-prompts / review。
 fresh-agent 双臂盲测、独立 reviewer verdict 与 protected-release gate 三项未完成，
 由维护者知情后放行；相应记录以 `hold` 而非 `promotion` 留在仓库外的受控工作区。
 
-[未发布]: https://github.com/worldwonderer/drama-skills/compare/v0.3.0...HEAD
+[未发布]: https://github.com/worldwonderer/drama-skills/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/worldwonderer/drama-skills/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/worldwonderer/drama-skills/compare/v0.4.2...v0.5.0
+[0.4.2]: https://github.com/worldwonderer/drama-skills/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/worldwonderer/drama-skills/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/worldwonderer/drama-skills/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/worldwonderer/drama-skills/compare/v0.2.0...v0.3.0
 [0.3.0-rc.1]: https://github.com/worldwonderer/drama-skills/compare/v0.2.0...v0.3.0-rc.1
 [0.2.0]: https://github.com/worldwonderer/drama-skills/releases/tag/v0.2.0

--- a/evaluations/content_quality_gate.py
+++ b/evaluations/content_quality_gate.py
@@ -862,7 +862,9 @@ def evaluate(
                     f"{case_id} {replicate_id}: exactly {expected_run_count} balanced judge runs are required"
                 )
             family_counts: Counter[str] = Counter()
-            family_positions = {family: Counter() for family in FAMILIES}
+            family_positions: dict[str, Counter[str]] = {
+                family: Counter() for family in FAMILIES
+            }
             replicate_baseline_scores: list[float] = []
             replicate_candidate_scores: list[float] = []
             replicate_baseline_dimensions: dict[str, list[float]] = defaultdict(list)

--- a/skills/short-drama-write/SKILL.md
+++ b/skills/short-drama-write/SKILL.md
@@ -65,14 +65,15 @@ license: MIT
 
 ## 时长估算（按需）
 
-用户问时长时才把索引写入临时目录。`--speaker` 必须替换为本集实际说话者；只有存在项目配置时才
-添加 `--project short-drama.json`：
+用户问时长时才把索引写入系统临时目录。先用 Python 查询跨平台临时目录，把第一条命令打印的完整
+路径原样替换进后两条命令的引号内。以下每条都是一行完整命令，不依赖 shell 变量或续行符；Windows
+没有 `python3` 命令时使用 `py -3`。`--speaker` 的示例值必须替换为本集实际说话者；只有存在项目
+配置时才添加 `--project short-drama.json`：
 
-```bash
-TMP_DIR=$(mktemp -d)
-python3 "{技能目录}/scripts/screenplay_index.py" 剧集/EP001/剧本.md --output "$TMP_DIR/index.jsonl" \
-  --speaker <本集角色一> --speaker <本集角色二>
-python3 "{技能目录}/scripts/duration_estimate.py" 剧集/EP001/剧本.md --index "$TMP_DIR/index.jsonl"
+```text
+python3 -c "from pathlib import Path; import tempfile, uuid; print(Path(tempfile.gettempdir()) / ('short-drama-' + uuid.uuid4().hex + '.jsonl'))"
+python3 "{技能目录}/scripts/screenplay_index.py" "剧集/EP001/剧本.md" --output "粘贴第一条命令输出的完整路径" --speaker "本集角色一" --speaker "本集角色二"
+python3 "{技能目录}/scripts/duration_estimate.py" "剧集/EP001/剧本.md" --index "粘贴第一条命令输出的完整路径"
 ```
 
 估算是参考，不是门禁；没有语速或动作段速率时只报告可数事实，不猜秒数。但任务已给目标时长时，

--- a/tests/test_creator_first_golden.py
+++ b/tests/test_creator_first_golden.py
@@ -126,6 +126,11 @@ def heading_ids(document: str, prefix: str) -> list[str]:
     return re.findall(rf"^## ({prefix}[A-Z0-9-]+)\b", document, flags=re.MULTILINE)
 
 
+def headings(document: str, level: int) -> list[str]:
+    marker = "#" * level
+    return re.findall(rf"^{marker} (.+)$", document, flags=re.MULTILINE)
+
+
 def frozen_prompt(document: str, shot_id: str) -> str:
     section = document.split(f"## {shot_id}", 1)[1].split("\n## ", 1)[0]
     return section.split("### 冻结关键帧提示词", 1)[1]
@@ -165,24 +170,30 @@ class CreatorFirstGoldenTests(unittest.TestCase):
         self.assertFalse(list(EPISODE.rglob("*.json")))
         self.assertFalse(list(EPISODE.rglob("*.jsonl")))
 
-    def test_documents_are_complete_creator_content_not_placeholders(self) -> None:
+    def test_documents_follow_the_creator_markdown_contract(self) -> None:
         for name in EXPECTED:
-            content = text(name)
-            self.assertGreater(len(content), 500, name)
-            self.assertNotRegex(content, r"(?i)TODO|TBD|PLACEHOLDER|待补|待定")
+            document = text(name)
+            with self.subTest(document=name):
+                self.assertEqual(len(headings(document, 1)), 1)
+                self.assertGreater(len(headings(document, 2)), 0)
 
         screenplay = text("剧本.md")
-        self.assertGreaterEqual(
-            len(re.findall(r"^## EP001-SC\d+ (?:内|外|内外) · ", screenplay, re.MULTILINE)),
-            2,
+        scene_ids = re.findall(
+            r"^## (EP001-SC\d+) (?:内|外|内外) · \S.* · \S.*$",
+            screenplay,
+            re.MULTILINE,
         )
-        self.assertIn("江晨：", screenplay)
-        self.assertIn("剩余 4 天 23:59:58", screenplay)
+        self.assertGreaterEqual(len(scene_ids), 2)
+        self.assertEqual(len(scene_ids), len(set(scene_ids)))
 
         visual = text("视觉设定.md")
-        for section in ("## 人物", "## 地点", "## 道具", "识别锚点"):
-            self.assertIn(section, visual)
-        self.assertEqual(visual.count("- 识别锚点："), 6)
+        visual_entries = [heading.split(" · ", 1) for heading in headings(visual, 2)]
+        self.assertTrue(all(len(entry) == 2 and all(entry) for entry in visual_entries))
+        self.assertEqual({entry[0] for entry in visual_entries}, {"人物", "地点", "道具"})
+        self.assertEqual(
+            len(re.findall(r"^- 识别锚点：\S.+$", visual, re.MULTILINE)),
+            len(visual_entries),
+        )
 
     def test_storyboard_and_motion_cover_the_same_unique_shots(self) -> None:
         storyboard = text("分镜.md")
@@ -195,8 +206,8 @@ class CreatorFirstGoldenTests(unittest.TestCase):
         self.assertEqual(len(shot_ids), len(set(shot_ids)))
         self.assertEqual(len(motion_ids), len(set(motion_ids)))
         self.assertEqual(motion_shots, shot_ids)
-        self.assertEqual(storyboard.count("### 冻结关键帧提示词"), len(shot_ids))
-        self.assertEqual(video.count("### 可复制提示词"), len(shot_ids))
+        self.assertEqual(headings(storyboard, 3), ["冻结关键帧提示词"] * len(shot_ids))
+        self.assertEqual(headings(video, 3), ["可复制提示词"] * len(shot_ids))
 
         storyboard_durations = {
             shot_id: int(re.search(r"^- 时长：(\d+)s$", body, re.MULTILINE).group(1))
@@ -210,6 +221,14 @@ class CreatorFirstGoldenTests(unittest.TestCase):
         }
         self.assertEqual(motion_durations, storyboard_durations)
 
+        screenplay_scenes = set(heading_ids(text("剧本.md"), "EP001-SC"))
+        storyboard_scenes = {
+            match.group(1)
+            for body in sections(storyboard, "SHOT-").values()
+            if (match := re.search(r"^- 来源：(EP001-SC\d+)$", body, re.MULTILINE))
+        }
+        self.assertEqual(storyboard_scenes, screenplay_scenes)
+
     def test_each_shot_names_its_image_references(self) -> None:
         image_ids = set(heading_ids(text("图片提示词.md"), "IMG-"))
         for shot_id, body in sections(text("分镜.md"), "SHOT-").items():
@@ -220,13 +239,11 @@ class CreatorFirstGoldenTests(unittest.TestCase):
                 self.assertTrue(referenced)
                 self.assertLessEqual(referenced, image_ids)
 
-    def test_frozen_keyframes_are_motion_start_states(self) -> None:
+    def test_frozen_keyframes_are_copyable_markdown_blocks(self) -> None:
         storyboard = text("分镜.md")
-        self.assertIn("formal neutral expression", frozen_prompt(storyboard, "SHOT-EP001-003"))
-        self.assertNotIn("8,472", frozen_prompt(storyboard, "SHOT-EP001-005"))
-        self.assertNotIn("配乐", frozen_prompt(storyboard, "SHOT-EP001-006"))
-        self.assertIn("screen completely dark", frozen_prompt(storyboard, "SHOT-EP001-007"))
-        self.assertNotIn("23:59", frozen_prompt(storyboard, "SHOT-EP001-008"))
+        for shot_id in heading_ids(storyboard, "SHOT-"):
+            with self.subTest(shot=shot_id):
+                self.assertRegex(frozen_prompt(storyboard, shot_id), r"^\s*>\s*\S")
 
     def test_screenplay_is_accepted_by_the_documented_indexer(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -244,36 +261,12 @@ class CreatorFirstGoldenTests(unittest.TestCase):
         ids = heading_ids(prompts, "IMG-")
         self.assertGreater(len(ids), 0)
         self.assertEqual(len(ids), len(set(ids)))
-        self.assertEqual(prompts.count("### 可复制提示词"), len(ids))
+        self.assertEqual(headings(prompts, 3), ["可复制提示词"] * len(ids))
         for image_id, body in sections(prompts, "IMG-").items():
             with self.subTest(prompt=image_id):
-                self.assertRegex(body.lower(), r"no [^\n>]*watermark")
-
-    def test_story_critical_text_and_lines_reach_the_delivery_prompts(self) -> None:
-        downstream = "\n".join((text("分镜.md"), text("图片提示词.md"), text("视频提示词.md")))
-        for fact in (
-            "微博 2",
-            "短视频 0",
-            "全站创作者榜",
-            "演唱",
-            "伴奏素材《亮剑》×1",
-            "剩余 4 天 23:59:58",
-            "一片没人动过的地",
-            "我不懂音乐。连抄都抄不出来。",
-        ):
-            with self.subTest(fact=fact):
-                self.assertIn(fact, downstream)
-
-    def test_every_screenplay_tag_is_documented_for_creator_first(self) -> None:
-        guidance = "\n".join(
-            (
-                (ROOT / "skills/short-drama-write/SKILL.md").read_text(encoding="utf-8"),
-                (ROOT / "skills/short-drama/references/creator-documents.md").read_text(encoding="utf-8"),
-            )
-        )
-        for tag in screenplay_index.SUPPORTED_TAGS:
-            with self.subTest(tag=tag):
-                self.assertIn(f"[{tag}]", guidance)
+                prompt_headings = headings(body, 3)
+                self.assertEqual(prompt_headings, ["可复制提示词"])
+                self.assertRegex(body.split("### ", 1)[1], r"\n>\s*\S")
 
     def test_every_creator_knowledge_reference_is_reachable(self) -> None:
         for skill_name in ACTIVE_CREATOR_SKILLS:
@@ -293,33 +286,6 @@ class CreatorFirstGoldenTests(unittest.TestCase):
             actual = {path.name for path in references.glob("*.md")}
             with self.subTest(skill=skill_name):
                 self.assertEqual(actual, expected)
-
-    def test_creator_knowledge_does_not_route_back_to_retired_artifacts(self) -> None:
-        retired = (
-            "screenplay.md",
-            "screenplay-index.jsonl",
-            "creator_authority",
-            "creator-decisions",
-            "set-authority",
-            "创作者决策/",
-            "设定集/voice-casting.md",
-            "shots.jsonl",
-            "motion-specs.jsonl",
-            "look_development",
-            "record_id",
-            "evidence_refs",
-            "target_ref",
-            "coverage_scope",
-            "supersession-decision.example.json",
-            "accepted structured spec",
-        )
-        for skill_name in ACTIVE_CREATOR_SKILLS:
-            references = ROOT / "skills" / skill_name / "references"
-            for path in references.glob("*.md"):
-                document = path.read_text(encoding="utf-8")
-                for term in retired:
-                    with self.subTest(skill=skill_name, reference=path.name, term=term):
-                        self.assertNotIn(term, document)
 
     def test_creator_rule_catalogs_keep_every_craft_rule(self) -> None:
         expected = {
@@ -348,34 +314,6 @@ class CreatorFirstGoldenTests(unittest.TestCase):
             actual = set(re.findall(r"\b(?:SCR|AST|IMG|SHT|VID|CON|REV)-\d{2}\b", contract))
             with self.subTest(skill=skill_name):
                 self.assertEqual(actual, rule_ids)
-
-    def test_creator_skills_have_one_layout_not_a_compatibility_branch(self) -> None:
-        for skill_name in CREATOR_SKILLS:
-            document = (ROOT / "skills" / skill_name / "SKILL.md").read_text(encoding="utf-8")
-            with self.subTest(skill=skill_name):
-                self.assertNotIn("旧项目兼容", document)
-                self.assertNotIn("已有结构化", document)
-
-        produce = (ROOT / "skills/short-drama-produce/SKILL.md").read_text(encoding="utf-8")
-        self.assertNotIn("旧版规格", produce)
-        for retired_name in ("image-prompt-specs.jsonl", "motion-specs.jsonl", "voice-record-sheet.jsonl"):
-            self.assertNotIn(retired_name, produce)
-
-    def test_review_outputs_creator_readable_markdown(self) -> None:
-        review = (ROOT / "skills/short-drama-review/SKILL.md").read_text(encoding="utf-8")
-        self.assertIn("审查/EP001-审查.md", review)
-        self.assertNotIn("findings.jsonl", review)
-        self.assertNotIn("verdict.json", review)
-
-    def test_removed_pipeline_does_not_return(self) -> None:
-        contract = (
-            ROOT / "skills/short-drama/references/creator-workflow.md"
-        ).read_text(encoding="utf-8")
-        # ddfdbe3 briefly reintroduced a nested creator root and a generated
-        # state module. These guards lock the corrected simple layout.
-        self.assertNotIn("创作内容/剧集", contract)
-        self.assertNotIn("creator_state.py", contract)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
本版将默认短剧创作路径升级为 creator-first 五文档，并把短剧写作规则改为按题面实际承诺的机制启用。详细创作 knowhow 保持不变，Dashboard、漫剧关键帧词表和端到端漫剧指引同步适配新流程。

## 破坏性改动

creator-first 不是旧结构化项目的就地升级格式。普通创作现在以以下五份 Markdown 作为创作真相：

- `剧本.md`
- `视觉设定.md`
- `分镜.md`
- `图片提示词.md`
- `视频提示词.md`

新流程不再为普通创作逐批生成 JSON/JSONL、索引、指纹、覆盖表或 QA 记录。旧、新两套创作真相不得在同一项目根目录并排维护。

## 迁移与回滚

- v0.5 在途项目继续锁定 `v0.5.0`。
- 升级时新建 creator-first 项目根目录，逐集人工转移并重新确认五份创作真相。
- 旧结构化产物、生产记录与审计证据只读保留，不作为新项目的并行真相来源。
- 需要回滚时回到原 v0.5 项目根目录；不要把新五文档反向写回旧结构化目录。

## 主要改动

- Dashboard 原生识别 creator-first 中文文档和媒体进度。
- SCR-13、SCR-14、SCR-16、SCR-17 改为按对应叙事机制启用。
- 详细写作 knowhow 保留，并补充精确事实、证据停止条件和镜头外负面事实的适用边界。
- 内容质量门禁升级为隔离生成、prompt-only 盲评和可信 seal 绑定的可复现协议。
- 新增漫剧关键帧视觉词表与《漫剧 Creator-first 全流程》。
- 修复 GitHub 上无法正确闭合的 Markdown 粗体标记。
- 明确禁止以纯字符串包含断言钉死文案的单元测试，并将现有脆弱测试改为结构、引用关系和可执行行为验证。
- 时长估算示例改为跨平台临时路径流程；内容质量 gate 纳入 CI 类型检查。

逐条说明见 `CHANGELOG.md`。

## 发布验证

| 检查 | 结果 |
|---|---|
| Python 3.9 全量测试 | 379/379 通过 |
| protected release gate | 379/379 通过 |
| 主工作流回归闸门 | 10/10 通过 |
| Ruff / mypy / Node / diff check | 通过 |
| 纯字符串测试规则扫描 | 通过 |
| 独立代码复核 | PASS |
| 独立架构与发布复核 | PASS |
