### PR TITLE
docs: migrate repository namespace to zenstory-ai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1127,13 +1127,13 @@ image-prompts / storyboard / video-prompts / review。
 fresh-agent 双臂盲测、独立 reviewer verdict 与 protected-release gate 三项未完成，
 由维护者知情后放行；相应记录以 `hold` 而非 `promotion` 留在仓库外的受控工作区。
 
-[未发布]: https://github.com/worldwonderer/drama-skills/compare/v0.6.0...HEAD
-[0.6.0]: https://github.com/worldwonderer/drama-skills/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/worldwonderer/drama-skills/compare/v0.4.2...v0.5.0
-[0.4.2]: https://github.com/worldwonderer/drama-skills/compare/v0.4.1...v0.4.2
-[0.4.1]: https://github.com/worldwonderer/drama-skills/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/worldwonderer/drama-skills/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/worldwonderer/drama-skills/compare/v0.2.0...v0.3.0
-[0.3.0-rc.1]: https://github.com/worldwonderer/drama-skills/compare/v0.2.0...v0.3.0-rc.1
-[0.2.0]: https://github.com/worldwonderer/drama-skills/releases/tag/v0.2.0
-[0.1.0]: https://github.com/worldwonderer/drama-skills/releases/tag/v0.1.0
+[未发布]: https://github.com/zenstory-ai/drama-skills/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/zenstory-ai/drama-skills/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/zenstory-ai/drama-skills/compare/v0.4.2...v0.5.0
+[0.4.2]: https://github.com/zenstory-ai/drama-skills/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/zenstory-ai/drama-skills/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/zenstory-ai/drama-skills/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/zenstory-ai/drama-skills/compare/v0.2.0...v0.3.0
+[0.3.0-rc.1]: https://github.com/zenstory-ai/drama-skills/compare/v0.2.0...v0.3.0-rc.1
+[0.2.0]: https://github.com/zenstory-ai/drama-skills/releases/tag/v0.2.0
+[0.1.0]: https://github.com/zenstory-ai/drama-skills/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 # Drama Skills
 
-[![CI](https://github.com/worldwonderer/drama-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/worldwonderer/drama-skills/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/worldwonderer/drama-skills)](https://github.com/worldwonderer/drama-skills/releases/latest)
+[![CI](https://github.com/zenstory-ai/drama-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/zenstory-ai/drama-skills/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/zenstory-ai/drama-skills)](https://github.com/zenstory-ai/drama-skills/releases/latest)
 [![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![License](https://img.shields.io/github/license/worldwonderer/drama-skills)](LICENSE)
+[![License](https://img.shields.io/github/license/zenstory-ai/drama-skills)](LICENSE)
 
 面向编剧、漫剧工作室和编导的 AI 短剧创作工作流。十个技能把一个点子或一部长篇材料，
 一路做成分集剧本、资产设定、图片提示词、分镜关键帧和视频提示词，
@@ -37,14 +37,14 @@ Seedance、GPT Image 2 与 MiniMax Music 的可选 adapter，但项目文件和�
 Codex 等支持导入 GitHub 仓库的智能体：
 
 ```
-安装这些技能 https://github.com/worldwonderer/drama-skills
+安装这些技能 https://github.com/zenstory-ai/drama-skills
 ```
 
 <details>
 <summary>手动链接（可安装全部，也可只链接需要的技能）</summary>
 
 ```bash
-git clone https://github.com/worldwonderer/drama-skills.git && cd drama-skills
+git clone https://github.com/zenstory-ai/drama-skills.git && cd drama-skills
 
 # Claude Code
 mkdir -p "$HOME/.claude/skills"

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,10 +2,10 @@
 
 # Drama Skills
 
-[![CI](https://github.com/worldwonderer/drama-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/worldwonderer/drama-skills/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/github/v/release/worldwonderer/drama-skills)](https://github.com/worldwonderer/drama-skills/releases/latest)
+[![CI](https://github.com/zenstory-ai/drama-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/zenstory-ai/drama-skills/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/zenstory-ai/drama-skills)](https://github.com/zenstory-ai/drama-skills/releases/latest)
 [![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![License](https://img.shields.io/github/license/worldwonderer/drama-skills)](LICENSE)
+[![License](https://img.shields.io/github/license/zenstory-ai/drama-skills)](LICENSE)
 
 An AI short-drama creation suite for screenwriters, motion-comic studios, and
 directors. Ten skills take an idea or a long-form source all the way to episode
@@ -47,14 +47,14 @@ Needs **Python 3.9 or newer** (the version macOS ships is enough).
 Just tell Claude Code, Codex, or any agent that can import a GitHub repository:
 
 ```
-Install this skill suite: https://github.com/worldwonderer/drama-skills
+Install this skill suite: https://github.com/zenstory-ai/drama-skills
 ```
 
 <details>
 <summary>Manual linking (install all skills or only the ones you need)</summary>
 
 ```bash
-git clone https://github.com/worldwonderer/drama-skills.git && cd drama-skills
+git clone https://github.com/zenstory-ai/drama-skills.git && cd drama-skills
 
 # Claude Code
 mkdir -p "$HOME/.claude/skills"


### PR DESCRIPTION
## Summary
- update repository references from `worldwonderer/drama-skills` to `zenstory-ai/drama-skills`
- limit the migration patch to README.md, README_EN.md, and CHANGELOG.md
- preserve behavior and published artifacts

## Verification
- registered patch head: `876103286384b7dac863edab9489437b5d1dce45`
- 379 Python unit tests passed locally
- Ruff passed locally
- mypy passed locally
- Node repository check passed locally

This is the namespace-only follow-up after the GitHub repository transfer.
