### PR TITLE
docs(changelog): 自 v0.6.2 起采用组织统一的发布标准

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@
 版本号遵循 [语义化版本](https://semver.org/lang/zh-CN/)。
 
 规则分级变化按其对创作者的约束力记录：`structural_invariant` 与 `reviewed_invariant`
-的新增或收紧记为 **变更**（可能阻断既有产物），`craft_default` 与 `taste_option` 记为
-**新增**（可被创作者覆盖）。
+的新增或收紧记为 `Changed`（可能阻断既有产物），`craft_default` 与 `taste_option` 记为
+`Added`（可被创作者覆盖）。
 
-## [未发布]
+自 `v0.6.2` 起，小节名采用 Keep a Changelog 的六个英文类别（`Added` / `Changed` /
+`Deprecated` / `Removed` / `Fixed` / `Security`），正文仍为中文；`v0.6.1` 及更早的小节
+保持原样。
+
+## [Unreleased]
 
 ## [0.6.1] - 2026-08-25
 
@@ -1189,7 +1193,7 @@ image-prompts / storyboard / video-prompts / review。
 fresh-agent 双臂盲测、独立 reviewer verdict 与 protected-release gate 三项未完成，
 由维护者知情后放行；相应记录以 `hold` 而非 `promotion` 留在仓库外的受控工作区。
 
-[未发布]: https://github.com/zenstory-ai/drama-skills/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/zenstory-ai/drama-skills/compare/v0.6.1...HEAD
 [0.6.1]: https://github.com/zenstory-ai/drama-skills/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/zenstory-ai/drama-skills/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/zenstory-ai/drama-skills/compare/v0.4.2...v0.5.0


### PR DESCRIPTION
按 [zenstory-ai/.github 的 `release-writing` skill](https://github.com/zenstory-ai/.github/tree/main/skills/release-writing) 对齐组织标准。

## 改了什么

- `## [未发布]` → `## [Unreleased]`（含底部链接引用）
- 头部写明**自 `v0.6.2` 起**小节名用 Keep a Changelog 的六个英文类别，正文仍为中文
- 既有的规则分级说明保留，只把它指向的小节名改成英文：`structural_invariant` / `reviewed_invariant` 的新增或收紧 → `Changed`，`craft_default` / `taste_option` → `Added`

## 为什么保留本仓库自己的分级规则

本仓库那条「按对创作者的约束力分类」是 org 内最强的分级说明——它直接回答了最容易漏判的那一步。组织标准只统一小节**名称**，不替换各仓库的判断依据；两者不冲突。

## 不重写历史

`v0.6.1` 及更早保持原有中文小节名。改写它们不会让记录更准确。

## 验证

```
python3 -m unittest discover -s tests   # Ran 444 tests — OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)