### PR TITLE
fix(produce): read reference images in binary mode on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+**Windows 上的参考图不再被截断**。生产环节按描述符读参考图时缺 `O_BINARY`，Windows 因此按文本
+模式打开：读到第一个 `0x1A` 就停，`\r\n` 也被折成 `\n`。PNG 签名的第七个字节正是 `0x1A`，
+所以参考图以 5 字节发给供应商、换回 `invalid_image_file`（HTTP 400）——`references` 与
+`reference_bindings` 在这个平台上从未成功过。v0.6.1 给 Dashboard 做过同一处修复，生产环节漏掉了。
+POSIX 行为不变。
+
 ## [0.6.1] - 2026-08-25
 
 维护版本。解除两处挡住创作者的限制——Dashboard 在 Windows 上无法启动，图片提示词校验器用固定

--- a/skills/short-drama-produce/scripts/provider_adapters.py
+++ b/skills/short-drama-produce/scripts/provider_adapters.py
@@ -547,7 +547,9 @@ def _read_reference(path: Path) -> bytes:
         raise ValueError("reference is not a regular file")
     if before.st_size > MAX_REFERENCE_BYTES:
         raise ValueError("reference exceeds the provider input size limit")
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    # Windows opens files in text mode unless told otherwise, which stops the
+    # read at the first 0x1A byte -- the seventh byte of every PNG signature.
+    flags = os.O_RDONLY | getattr(os, "O_BINARY", 0) | getattr(os, "O_NOFOLLOW", 0)
     descriptor = os.open(path, flags)
     try:
         opened = os.fstat(descriptor)

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -399,6 +399,46 @@ class ProviderRuntimeTests(unittest.TestCase):
                 with self.assertRaisesRegex(ValueError, "size limit"):
                     provider_adapters._multipart({}, [path])
 
+    def test_reference_bytes_survive_a_text_mode_descriptor(self) -> None:
+        # 回归：_read_reference 曾用 os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        # 打开描述符。Windows 没有 O_BINARY 时那是文本模式的描述符——os.read 会
+        # 把每个 \r\n 折成 \n，并在第一个 0x1A（DOS 文件结束符）处停住。PNG 签名
+        # 是 89 50 4E 47 0D 0A 1A 0A，第七个字节正是 0x1A，于是每张参考图都以
+        # 5 字节送到 gpt-image-2，供应商回 invalid_image_file / HTTP 400，
+        # references 与 reference_bindings 在这个平台上从未成功过。
+        #
+        # POSIX 没有文本模式，直接断言读回的字节数无法在这里变红。所以本例把
+        # O_BINARY 立成一个真实常量，并让 os.read 在调用方没有点名二进制时按
+        # Windows CRT 的方式截断：断言的是这段代码有没有「要求」二进制模式。
+        payload = b"\x89PNG\r\n\x1a\nIHDR\r\ntail"
+        native_binary = getattr(os, "O_BINARY", 0)
+        probe = native_binary or 0x8000  # MSVC CRT 的 _O_BINARY
+        real_open, real_read = os.open, os.read
+        text_mode: set[int] = set()
+
+        def fake_open(target, flags, *args, **kwargs):  # type: ignore[no-untyped-def]
+            descriptor = real_open(
+                target, (flags & ~probe) | native_binary, *args, **kwargs
+            )
+            if not flags & probe:
+                text_mode.add(descriptor)
+            return descriptor
+
+        def fake_read(descriptor: int, length: int) -> bytes:
+            data = real_read(descriptor, length)
+            if descriptor in text_mode:
+                return data.replace(b"\r\n", b"\n").split(b"\x1a", 1)[0]
+            return data
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "reference.png"
+            path.write_bytes(payload)
+            with mock.patch.object(os, "O_BINARY", probe, create=True), mock.patch.object(
+                os, "open", fake_open
+            ), mock.patch.object(os, "read", fake_read):
+                content = provider_adapters._read_reference(path)
+        self.assertEqual(content, payload)
+
     def test_cli_selftest_and_safe_failure_do_not_expose_credentials(self) -> None:
         completed = subprocess.run(
             [sys.executable, str(SCRIPT), "--selftest"],


### PR DESCRIPTION
Fixes #78.

## What was broken

`_read_reference` opened its descriptor as `os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)`. CPython never sets the CRT `_fmode`, so on Windows that is a **text-mode** descriptor: `os.read` collapses every `\r\n` into `\n` and stops at the first `0x1A`, the DOS end-of-file byte.

A PNG signature is `89 50 4E 47 0D 0A 1A 0A`. The `0D 0A` folds into a single byte *before* the `1A` ends the read, so every reference image reached the provider as exactly **five bytes** — `89 50 4E 47 0A` — and gpt-image-2 answered `invalid_image_file` / HTTP 400. `references` and `reference_bindings` have never worked on Windows.

Truncation is only half of it. The CRLF folding applies to the whole file, so a reference containing no `0x1A` at all still arrives **corrupted** rather than merely short.

## Why this one site

`v0.6.1` made the same repair for the Dashboard — which is why `dashboard_server.py` already carries the `getattr(os, "O_BINARY", 0)` idiom this patch copies. The produce adapter was missed in that sweep.

`_read_reference` holds the **only** raw `os.read()` in the suite (`grep -rn 'os\.read(' skills/ tests/` → one hit). Every other descriptor goes straight into `os.fdopen()`, and `_io_FileIO___init___impl` calls `_setmode(fd, O_BINARY)` unconditionally on Windows — verified on the `3.9`, `3.11` and `3.14` branches (`Modules/_io/fileio.c:477 / 473 / 508`, top level, guarded only by `#if defined(MS_WINDOWS) || defined(__CYGWIN__)`), so it covers the whole CI matrix. No bytes are read between `os.open` and `os.fdopen` at any of those sites. That clears `production_tool.py:237/424/489/564/1381`, `project_tool.py:894` and `dashboard_server.py:767/793/960`. **No other call site needs the flag** — this is deliberately not a sweep.

## The test, and why it is shaped this way

`tests/test_provider_adapters.py` is not in the `windows-install` job's module list, and the obvious assertion — that `_read_reference` returns `path.stat().st_size` bytes — passes identically before and after the fix on Linux and macOS. Either way it would be green forever.

So the test stands `O_BINARY` up as a real constant and makes `os.read` truncate the way the Windows CRT does whenever the caller did not name binary mode. It asserts that this code *asks* for binary mode, which is behaviour, not source text. Without the fix it fails on **every** platform:

```
AssertionError: b'\x89PNG\n' != b'\x89PNG\r\n\x1a\nIHDR\r\ntail'
```

`ci.yml` is unchanged — no gate added.

## Verification

| gate | result |
|---|---|
| `unittest discover -s tests` on 3.9 / 3.10 / 3.14 | 445 tests, OK |
| `ruff@0.15.11 check .` | All checks passed |
| `mypy==2.3.0` (CI file list, 11 files) | Success, no issues |
| `node --check` dashboard `app.js` | OK |
| all 10 `skills/*/scripts/selftest.py` | pass |
| new test with the fix reverted | fails as quoted above |

**Not verified on real Windows** — no Windows machine was available. The CRT behaviour is established from UCRT `lowio/read.cpp` (`translate_text_mode_nolock` sets `FEOFLAG` on `CTRLZ` when `FDEV` is clear, i.e. for regular files specifically), the `os.open` documentation, and CPython source — not from observation. The Windows CI job will confirm the suite still passes there.

## Behaviour on POSIX

Bit-identical. `O_BINARY` does not exist outside Windows, so `getattr(..., 0)` leaves the flags integer unchanged.

## Notes on the report

The report is accurate down to the byte count. Two things for the record:

- Its repro snippet uses `os.O_NOFOLLOW` directly, which raises `AttributeError` on Windows. The production line uses `getattr(...)`, so the real flags there are plain `os.O_RDONLY` — a transcription slip, substance unaffected.
- The multipart figures (3,001 → 4,225,867) do not reconcile with one or two copies of the named 1,834,026-byte PNG; `_multipart` appends reference bytes raw with identical overhead either way. They look like they came from a different multi-reference job. Anyone reproducing with a single 1.8 MB PNG should expect ~1.83 MB and not read that as a failure to reproduce.

## Out of scope

A separate Windows-only defect turned up while sweeping and is **not** in this PR: ten `print(json.dumps(..., ensure_ascii=False))` sites across the checker scripts. With stdout redirected, `sys.stdout` falls back to `locale.getpreferredencoding(False)`; on a non-CJK code page that raises `UnicodeEncodeError` *after* the work is already written — traceback, exit code 1, and in `screenplay_index.py` the `--fail-on-review` contract never runs. Different mechanism, different blast radius, its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wmf5yd2kLViSsTN22CRQXf
