### PR TITLE
fix(cli): keep command-line output alive when stdout is redirected on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@
 `reference_bindings` 在这个平台上从未成功过。v0.6.1 给 Dashboard 做过同一处修复，生产环节漏掉了。
 POSIX 行为不变。
 
+**Windows 上的校验脚本不再把做完的活报成失败**。十二处命令行输出用 `ensure_ascii=False` 打印
+JSON，而输出里带着中文路径与中文条目。stdout 重定向到文件或管道时，Windows 用 ANSI 代码页而不是
+UTF-8：产物已经写完落盘，进程却在打印那一步抛 `UnicodeEncodeError`，退出码从 0 变成 1，
+`screenplay_index.py` 的 `--fail-on-review` 判定也不再执行。命令行 JSON 现在一律 ASCII 转义，
+与 `adapter-contract.md` 早已写明的可移植规则一致；写进文件的 JSON 与 JSONL 仍是原样的 UTF-8，
+创作者打开产物看到的中文不变。
+
 ## [0.6.1] - 2026-08-25
 
 维护版本。解除两处挡住创作者的限制——Dashboard 在 Windows 上无法启动，图片提示词校验器用固定

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ UTF-8：产物已经写完落盘，进程却在打印那一步抛 `UnicodeEncode
 与 `adapter-contract.md` 早已写明的可移植规则一致；写进文件的 JSON 与 JSONL 仍是原样的 UTF-8，
 创作者打开产物看到的中文不变。
 
+`creator_markdown_check.py` 不打印 JSON，直接写中文诊断与剧集路径，同一个重定向下也会抛错——
+一份完全合格的剧集退出码从 0 变成 1，不合格的剧集只剩一段 traceback，看不到哪里不对。它的 stdout
+现在与 stderr 用同一个 `backslashreplace` 处理器：终端能显示中文时照常显示，不能编码时退成转义，
+不再中断。
+
 ## [0.6.1] - 2026-08-25
 
 维护版本。解除两处挡住创作者的限制——Dashboard 在 Windows 上无法启动，图片提示词校验器用固定

--- a/evaluations/content_quality_gate.py
+++ b/evaluations/content_quality_gate.py
@@ -1342,9 +1342,9 @@ def main() -> int:
             trusted_seal_path=args.trusted_seal,
         )
     except (GateError, FileNotFoundError) as exc:
-        print(json.dumps({"passed": False, "error": str(exc)}, ensure_ascii=False))
+        print(json.dumps({"passed": False, "error": str(exc)}, ensure_ascii=True))
         return 2
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print(json.dumps(result, ensure_ascii=True, indent=2))
     return 0 if result["passed"] else 1
 
 

--- a/skills/short-drama-assets/scripts/asset_check.py
+++ b/skills/short-drama-assets/scripts/asset_check.py
@@ -259,7 +259,7 @@ def main() -> int:
     except (OSError, ValidationError) as exc:
         print(f"asset check failed: {exc}", file=sys.stderr)
         return 2
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print(json.dumps(result, ensure_ascii=True, indent=2))
     return 0
 
 

--- a/skills/short-drama-image-prompts/scripts/image_prompt_check.py
+++ b/skills/short-drama-image-prompts/scripts/image_prompt_check.py
@@ -435,7 +435,7 @@ def main() -> int:
     except (OSError, ValidationError) as exc:
         print(f"image prompt check failed: {exc}", file=sys.stderr)
         return 2
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print(json.dumps(result, ensure_ascii=True, indent=2))
     return 0
 
 

--- a/skills/short-drama-review/scripts/review_check.py
+++ b/skills/short-drama-review/scripts/review_check.py
@@ -317,7 +317,7 @@ def main() -> int:
     except (OSError, ValidationError) as exc:
         print(f"review check failed: {exc}", file=sys.stderr)
         return 2
-    print(json.dumps(result, ensure_ascii=False, indent=2))
+    print(json.dumps(result, ensure_ascii=True, indent=2))
     return 0
 
 

--- a/skills/short-drama-storyboard/scripts/storyboard_check.py
+++ b/skills/short-drama-storyboard/scripts/storyboard_check.py
@@ -816,7 +816,7 @@ def main(argv: list[str] | None = None) -> int:
     except CheckError as error:
         print(f"{type(error).__name__}: {error}", file=sys.stderr)
         return 2
-    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print(json.dumps(result, ensure_ascii=True, sort_keys=True))
     return 0 if result["status"] == "pass" else 1
 
 

--- a/skills/short-drama-video-prompts/scripts/container_check.py
+++ b/skills/short-drama-video-prompts/scripts/container_check.py
@@ -321,7 +321,7 @@ def main(argv: list[str] | None = None) -> int:
     except CheckError as error:
         print(f"{type(error).__name__}: {error}", file=sys.stderr)
         return 2
-    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print(json.dumps(result, ensure_ascii=True, sort_keys=True))
     return 0 if result["status"] == "pass" else 1
 
 

--- a/skills/short-drama-video-prompts/scripts/music_spec_check.py
+++ b/skills/short-drama-video-prompts/scripts/music_spec_check.py
@@ -319,7 +319,7 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, UnicodeError, ValidationError) as exc:
         print(str(exc), file=sys.stderr)
         return 2
-    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print(json.dumps(result, ensure_ascii=True, sort_keys=True))
     return 0
 
 

--- a/skills/short-drama-write/scripts/duration_estimate.py
+++ b/skills/short-drama-write/scripts/duration_estimate.py
@@ -298,7 +298,7 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("{}: {}".format(args.index, error))
 
     report = estimate(screenplay, blocks, project, review)
-    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    print(json.dumps(report, ensure_ascii=True, indent=2, sort_keys=True))
     # An estimate is never a verdict, so this exits successfully even when the
     # episode lands far from its target. Blocking here would turn a reported
     # number into the cross-project threshold this suite refuses to carry.

--- a/skills/short-drama-write/scripts/screenplay_index.py
+++ b/skills/short-drama-write/scripts/screenplay_index.py
@@ -1079,9 +1079,9 @@ def main(argv: list[str] | None = None) -> int:
             no_previous=args.no_previous,
         )
     except (OSError, UnicodeDecodeError, ValueError) as error:
-        print(json.dumps({"error": str(error)}, ensure_ascii=False), file=sys.stderr)
+        print(json.dumps({"error": str(error)}, ensure_ascii=True), file=sys.stderr)
         return 1
-    print(json.dumps(summary, ensure_ascii=False, sort_keys=True))
+    print(json.dumps(summary, ensure_ascii=True, sort_keys=True))
     if args.fail_on_review and summary["review_status"] != "clean":
         return 2
     return 0

--- a/skills/short-drama-write/scripts/voice_sheet_check.py
+++ b/skills/short-drama-write/scripts/voice_sheet_check.py
@@ -408,7 +408,7 @@ def main(argv: list[str] | None = None) -> int:
     except (CheckError, OSError) as error:
         print(f"{type(error).__name__}: {error}", file=sys.stderr)
         return 2
-    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print(json.dumps(result, ensure_ascii=True, sort_keys=True))
     return 0 if result["status"] == "pass" else 1
 
 

--- a/skills/short-drama/scripts/creator_markdown_check.py
+++ b/skills/short-drama/scripts/creator_markdown_check.py
@@ -318,6 +318,12 @@ def main() -> int:
     parser.add_argument("episode", type=Path, help="包含五份 Markdown 的剧集目录")
     parser.add_argument("--project-root", type=Path, help="用于解析 REF 项目相对路径")
     args = parser.parse_args()
+    # 诊断与剧集路径都是中文。stdout 重定向时 Windows 用 ANSI 代码页，默认的
+    # strict 处理器会在打印这一步抛错；stderr 早就是 backslashreplace，这里让
+    # stdout 用同一个处理器：能编码就照常显示中文，不能编码才退成转义。
+    reconfigure = getattr(sys.stdout, "reconfigure", None)
+    if reconfigure is not None:
+        reconfigure(errors="backslashreplace")
     errors = validate_episode(args.episode, args.project_root)
     if errors:
         for error in errors:

--- a/tests/test_creator_first_golden.py
+++ b/tests/test_creator_first_golden.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import re
 import shutil
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path, PurePosixPath
@@ -393,6 +396,38 @@ class CreatorFirstGoldenTests(unittest.TestCase):
 
     def test_creator_markdown_validator_accepts_the_golden_episode(self) -> None:
         self.assertEqual(creator_markdown_check.validate_episode(EPISODE, ROOT), [])
+
+    def test_validator_cli_survives_a_non_utf8_stdout_encoding(self) -> None:
+        """回归：CLI 用 print(f"...") 直接写 stdout，而诊断与剧集路径都是中文。
+
+        stdout 重定向到文件或管道时 Windows 用 ANSI 代码页，默认的 strict 处理器
+        在打印那一步抛 UnicodeEncodeError：一份完全合格的剧集退出码从 0 变成 1，
+        不合格的剧集则只剩一段 traceback，创作者看不到到底哪里不对。stderr 早已
+        是 backslashreplace，所以只有 stdout 会这样。POSIX 上用 PYTHONIOENCODING
+        能走到同一个 TextIOWrapper，这条在开发机上就会红。
+        """
+
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            episode = project / "剧集/EP001"
+            episode.parent.mkdir(parents=True)
+            shutil.copytree(EPISODE, episode)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "skills/short-drama/scripts/creator_markdown_check.py"),
+                    str(episode),
+                    "--project-root",
+                    str(project),
+                ],
+                check=False,
+                capture_output=True,
+                encoding="utf-8",
+                env={**os.environ, "PYTHONIOENCODING": "ascii"},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(result.stdout.startswith("OK: "), result.stdout)
 
     def test_creator_markdown_validator_accepts_a_real_ref_contract(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_screenplay_index.py
+++ b/tests/test_screenplay_index.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -593,6 +594,46 @@ class ScreenplayIndexTests(unittest.TestCase):
                 ["scene_heading", "comment", "dialogue"],
             )
 
+    def test_cli_summary_survives_a_non_utf8_stdout_encoding(self) -> None:
+        """回归：成功摘要曾用 ensure_ascii=False 打印，而摘要里带着输出路径。
+
+        stdout 重定向到文件或管道时，Windows 用的是 ANSI 代码页而不是 UTF-8；
+        本仓库的路径含中文，于是索引已经写完落盘之后，进程才在打印那一步抛
+        UnicodeEncodeError，退出码从 0 变成 1，后面的 --fail-on-review 判定也
+        不再执行——调用方据退出码判断，会把做完的活当成失败。POSIX 上用
+        PYTHONIOENCODING 能触发同一个 TextIOWrapper 路径，所以这条在开发机上
+        就会红，不必等 Windows runner。
+        """
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "剧集"
+            root.mkdir()
+            source = root / "剧本.md"
+            source.write_bytes(
+                (
+                    "# EP001 夜班\n\n"
+                    "## EP001-SC001 内 · 档案室 · 夜\n\n"
+                    "林岚：签字不是我的。\n"
+                ).encode()
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(source),
+                    "--output",
+                    str(root / "索引.jsonl"),
+                    "--speaker",
+                    "林岚",
+                ],
+                check=False,
+                capture_output=True,
+                encoding="utf-8",
+                env={**os.environ, "PYTHONIOENCODING": "ascii"},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(result.stdout)["review_status"], "clean")
 
     def test_fullwidth_dialect_tag_is_diagnosed_without_dropping_its_block(self) -> None:
         """The diagnosis must not renumber block IDs downstream artifacts cite."""


### PR DESCRIPTION
Stacked on #79 — base is `fix/windows-reference-binary-mode`, so review only the top two commits. GitHub retargets this to `main` once #79 merges.

One user-visible failure — **CLI output kills the process when stdout is redirected on Windows** — with two different mechanisms, one commit each.

## The shared cause

When stdout is **redirected** on Windows, Python does not use UTF-8. It falls back to `locale.getpreferredencoding(False)`, the ANSI code page, with the `strict` error handler. Attached to a console `_WindowsConsoleIO` saves it, which is why this hides in interactive use and only bites under `>` or a pipe. Every affected payload carries Chinese in normal operation: project paths (`剧集/`, `输入/`, `派生/`), scene headings, speaker names, rule text.

`sys.stderr` is unaffected throughout — its default error handler has been `backslashreplace` since 3.5, so it never raises.

## Commit 1 — twelve `json.dumps` sites

`print(json.dumps(..., ensure_ascii=False))` across ten scripts. **The success-path sites are the damaging ones**: `screenplay_index.py` writes the index to disk, then dies in the summary print — exit code **0 → 1 after the work is done**, and the `--fail-on-review` return below it never runs. A caller gating on exit code treats finished work as a failure.

Not a new convention — the existing one. `adapter-contract.md` has said since fda8675 (*"fix: make adapter JSON locale independent"*):

> Portable adapters should ASCII-escape JSON strings so Windows locale settings cannot corrupt project paths

Four scripts already comply. This applies it to the rest.

**Scope is deliberately narrow: only writes to a stream change.** The `ensure_ascii=False` calls that `.encode("utf-8")` into files or HTTP bodies are untouched — `project_tool.py:174/800/1501`, `production_tool.py:327`, `episode_intake.py:364`, `dashboard_server.py:1060`, `provider_adapters.py:502`, and the JSONL writer at `screenplay_index.py:846`. Flipping those would have changed creators' on-disk artifacts, which is the trap in a naive sweep. What a creator opens is unchanged; only machine-read CLI JSON gains `\uXXXX`, which every parser decodes transparently.

## Commit 2 — `creator_markdown_check.py`, which `ensure_ascii` cannot reach

It prints with `print(f"ERROR: {error}")` and `print(f"OK: {args.episode}")` — no JSON, no `ensure_ascii` to set. Every diagnostic in `validate_episode` is written in Chinese, and the documented invocation is `creator_markdown_check.py 剧集/<EP> --project-root .`, so the success line prints a Chinese path.

Measured against the golden example copied to the documented layout, `PYTHONIOENCODING=ascii` standing in for the ANSI code page:

| | before | after |
|---|---|---|
| valid episode | **exit 1**, `UnicodeEncodeError` at `print(f"OK: ...")` | exit 0, `OK: 剧集/EP001` |
| invalid episode | exit 1, one traceback instead of the error list | exit 1, every error listed, escaped |

The valid-episode case is the same blocker class as `screenplay_index.py`: a clean episode reports as broken. The invalid case keeps its exit code but loses the diagnostics that are the whole point of the tool — the loop aborts on the first error.

**Why not forced escaping here.** These diagnostics are read by people; escaping them unconditionally would make the tool's output unreadable on the platform where it was never broken. Giving `sys.stdout` the `backslashreplace` handler `sys.stderr` already has means Chinese still prints as Chinese wherever the stream can encode it, and degrades to escapes only where the alternative is a crash. Output on a UTF-8 terminal is byte-identical to before.

## Correction to an earlier claim in this PR

The first version of this description said the `print(f"...: {error}", file=sys.stderr)` handlers "degrade to a traceback" and were a known remaining gap. **That was wrong** — stderr's default error handler is already `backslashreplace`, so those sites never raise. Verified:

```
$ PYTHONIOENCODING=ascii python3 -c 'import sys; print(sys.stdout.errors, sys.stderr.errors)'
strict backslashreplace
```

stdout, whose default is `strict`, was the real gap; commit 2 closes it. No stderr site needed changing.

## The tests

Two, one per mechanism, each on its worst-consequence site. `PYTHONIOENCODING` drives the same `TextIOWrapper` as the Windows locale fallback, so both reproduce the failure **on POSIX** and go red on a developer machine rather than only on a Windows runner:

```
UnicodeEncodeError: 'ascii' codec can't encode characters in position 118-119   # screenplay_index
UnicodeEncodeError: 'ascii' codec can't encode characters in position 4-5       # creator_markdown_check
```

`ci.yml` is unchanged — no gate added.

## Verification

| gate | result |
|---|---|
| `unittest discover -s tests` on 3.9 / 3.14 | 447 tests, OK (was 445) |
| `ruff@0.15.11 check .` | All checks passed |
| `mypy==2.3.0` (CI file list, 11 files) | Success, no issues |
| `node --check` dashboard `app.js` | OK |
| all 10 `skills/*/scripts/selftest.py` | pass |
| each new test with its fix reverted | fails as quoted above |

**Not verified on real Windows** — no machine available. The locale fallback is reproduced via `PYTHONIOENCODING`, which exercises the same code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wmf5yd2kLViSsTN22CRQXf
