### PR TITLE
release: 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-08-30
+
+本版无需迁移，既有项目和目录结构不变。三项能力来自创作者实跑反馈（#81）：跨镜的服装与道具
+颜色可以锁住、本地创作台可以常驻、跑完的项目有了一条导出命令。`Changed` 里的两条收紧都是
+opt-in——不声明连续性锁的项目行为与 0.6.1 相同。
+
 ### Added
 
 **`project_tool.py export`**：把每集现有的五份创作文档与 `剧集/<EP>/制作成果/` 复制成一份交付
@@ -1286,7 +1292,8 @@ image-prompts / storyboard / video-prompts / review。
 fresh-agent 双臂盲测、独立 reviewer verdict 与 protected-release gate 三项未完成，
 由维护者知情后放行；相应记录以 `hold` 而非 `promotion` 留在仓库外的受控工作区。
 
-[Unreleased]: https://github.com/zenstory-ai/drama-skills/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/zenstory-ai/drama-skills/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/zenstory-ai/drama-skills/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/zenstory-ai/drama-skills/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/zenstory-ai/drama-skills/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/zenstory-ai/drama-skills/compare/v0.4.2...v0.5.0


### PR DESCRIPTION
把 `## [Unreleased]` 切成 `## [0.6.2] - 2026-08-30`，补 compare 链接，上方留一个新的空 Unreleased 节。只改 CHANGELOG.md。

本版内容全部来自 #82（closes #81）：

- **Added**：`project_tool.py export`（导出交付）、Dashboard `--detach/--status/--stop/--restart`（常驻）、目标模型能力档案、MiniMax H3 视频 adapter。
- **Changed**：跨镜一致性锁 `CON-07`/`IMG-13`（structural_invariant）与 `VID-23`（reviewed_invariant）。
- **Fixed**：两处 Windows 问题（参考图按文本模式被截断；命令行输出重定向时把做完的活报成失败）。

**升级影响：无需迁移，无需动作。** `Changed` 的两条都是 opt-in——不声明连续性锁的项目、未声明目标模型能力的项目，行为与 0.6.1 相同；既有产物不会被新规则阻断。

小节名按组织标准用英文六类，顺序 Added / Changed / Fixed，正文中文。这是 [#77](https://github.com/zenstory-ai/drama-skills/pull/77) 约定的「自 v0.6.2 起生效」的第一版。