### PR TITLE
fix(assets): 连续性锁的语言取值与校验器不一致

### DIFF
--- a/skills/short-drama-assets/references/continuity-lock.md
+++ b/skills/short-drama-assets/references/continuity-lock.md
@@ -40,7 +40,11 @@
 
 `锁面` 是**要被逐字带进提示词正文的那一小段字**，不是描述，也不是给人读的说明：
 
-- 用项目的提示词语言写（`short-drama.json#/format/prompt_language`，没有配置时是 `en`），
+- 用**可复制正文实际使用的语言**写，取值顺序与 `creator_markdown_check.py` 一致：
+  已接受的 `short-drama.json#/creator_authority/production_profile/choices/video_prompt_language`
+  优先，其次 `short-drama.json#/format/prompt_language`，都没有时是 `en`。**两者可能不同**——
+  创作者说明用中文、而目标模型方言要求正文用英文时，锁面必须跟正文走英文，跟着
+  `format/prompt_language` 写中文会让锁面在英文正文里永远匹配不上。
   因为它要落进可复制正文，不是落进创作者说明；
 - 只保留最小可辨识名词短语，通常是「颜色 + 材质/形制 + 物体」，例如
   `pale blue chunky knit wool sweater`；


### PR DESCRIPTION
实跑 EP001 视觉设定阶段暴露。资产阶段共报 9 处，本 PR 只改这一处已验证的规则冲突，其余随 RUN-LOG 统一处理。

## 问题

`continuity-lock.md` 写锁面要「用项目的提示词语言写（`short-drama.json#/format/prompt_language`）」。

但 `creator_markdown_check.py::_prompt_language()` 的实际取值顺序是：**已接受的 `production_profile.choices.video_prompt_language` 优先**，其次才是 `format/prompt_language`。

本次实跑正好命中差异：项目 `format.prompt_language = zh`（创作者说明用中文），而已接受的生产档案 `video_prompt_language = en`（MiniMax H3 方言要求正文英文）。**照文档写中文锁面，会在英文可复制正文里永远匹配不上**——而锁的全部作用就是让锁面原样出现在正文里。

已改为写明与校验器一致的取值顺序，并明确指出两者可能不同。

## 顺带修的项目内容（不在本 PR 的 skills 改动里）

剧本 SC001 的 `[画面文字]` 逐字包含「微博」「公众号」两个真实平台名，与本项目「公开演示不出现真实平台标识」的政策冲突——剧本已把发布平台虚构成「抖手」，却漏了账号类别这一行。已改为「博客号／视频站／短视频／图文号」，并把这条政策补进剧本顶部的改编取舍注释，避免再次漂移。这是我在剧本阶段审阅时漏掉的。

546 项测试，545 通过；唯一失败是 `test_dashboard_browser` 缺 Playwright 二进制，未改动的树上同样失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)