### PR TITLE
fix(assets): 锁面跨语言时无解，改为说明约束而不是指定一种语言

### DIFF
--- a/skills/short-drama-assets/references/continuity-lock.md
+++ b/skills/short-drama-assets/references/continuity-lock.md
@@ -40,11 +40,16 @@
 
 `锁面` 是**要被逐字带进提示词正文的那一小段字**，不是描述，也不是给人读的说明：
 
-- 用**可复制正文实际使用的语言**写，取值顺序与 `creator_markdown_check.py` 一致：
-  已接受的 `short-drama.json#/creator_authority/production_profile/choices/video_prompt_language`
-  优先，其次 `short-drama.json#/format/prompt_language`，都没有时是 `en`。**两者可能不同**——
-  创作者说明用中文、而目标模型方言要求正文用英文时，锁面必须跟正文走英文，跟着
-  `format/prompt_language` 写中文会让锁面在英文正文里永远匹配不上。
+- 锁面必须**逐字出现在它管到的每一份可复制正文里**。校验器会在三处查同一个字符串：
+  图片提示词正文、冻结关键帧提示词、视频提示词正文。
+- 这三处的语言不一定相同：图片提示词与冻结关键帧跟 `short-drama.json#/format/prompt_language`，
+  视频提示词优先跟已接受的 `production_profile.choices.video_prompt_language`。
+  **两者不同时（例如创作者说明 zh、H3 方言要求正文 en），一个字符串无法同时出现在三处**——
+  这是已知冲突，不是可以靠选对语言绕开的。两条出路：
+  - 优先把锁面写成**跨语言同形**的事实：色值（`#2F3A2C`）、编号、型号、专名、数字状态。
+    这类锁面在中英正文里都是同一串字符，三处都能原样命中；
+  - 确实需要自然语言描述时，把锁的 `镜头：` / `图片：` 范围收窄到语言一致的那些正文，
+    另一侧的同一事实另立一条锁，不要用一条锁去跨语言。
   因为它要落进可复制正文，不是落进创作者说明；
 - 只保留最小可辨识名词短语，通常是「颜色 + 材质/形制 + 物体」，例如
   `pale blue chunky knit wool sweater`；


### PR DESCRIPTION
**纠正 #118。** 那个 PR 的修法是错的，图片提示词阶段一跑就暴露了。

## 实际约束

`creator_markdown_check.py` 在**三处**查同一个锁面字符串：

| 正文 | 语言来源 | 本次实跑 |
|---|---|---|
| 图片提示词 | `format/prompt_language` | zh |
| 冻结关键帧提示词 | `format/prompt_language` | zh |
| 视频提示词 | 优先 `production_profile.choices.video_prompt_language` | en |

于是：

- **原文档**让锁面跟 `format`（zh）→ 视频正文（en）永远匹配不上；
- **#118** 改成跟 `video`（en）→ 图片正文与冻结关键帧（zh）反而匹配不上。

两种写法各让三分之二失效。**问题不在选哪种语言**，而在一个字符串本来就无法同时逐字出现在两种语言的正文里。#118 只是把失效的那一边换了个位置。

## 改法

写明这个约束，并给两条真正可行的出路：

1. **优先把锁面写成跨语言同形的事实**——色值（`#2F3A2C`）、编号、型号、专名、数字状态。这类字符串在中英正文里完全相同，三处都能原样命中。
2. 确实需要自然语言描述时，**把锁的 `镜头：`／`图片：` 范围收窄到语言一致的那些正文**，另一侧的同一事实另立一条锁，不用一条锁跨语言。

## 怎么发现的

按最新 skills 实跑《让你管账号》EP001。资产阶段报了语言来源与校验器不一致（→ #118），图片提示词阶段接着报「每段中文正文必然嵌一段英文，SKILL 未说明这种跨语言嵌入怎么写」——回头查校验器才看清是三处而不是两处，#118 的前提就是错的。

546 项测试，545 通过；唯一失败是 `test_dashboard_browser` 缺 Playwright 二进制，未改动的树上同样失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)