### PR TITLE
fix(check): 视频提示词的时长与分镜不一致时不再静默通过

### DIFF
--- a/skills/short-drama-video-prompts/references/stage-contract.md
+++ b/skills/short-drama-video-prompts/references/stage-contract.md
@@ -17,7 +17,7 @@
 
 | ID | Class | Knowledge |
 |---|---|---|
-| VID-01 | structural_invariant | Motion reads but cannot rewrite shot start/end/duration/dialogue and next-shot state. |
+| VID-01 | structural_invariant | Motion reads but cannot rewrite shot start/end/duration/dialogue and next-shot state. The duration a MOTION declares is compared against its SHOT: they must be the same number, because 时长 is what reaches the execution end and what VID-04/VID-13 arithmetic is built on. A downstream copy left behind by an upstream revision is a defect even though every string still parses. |
 | VID-02 | craft_default | Write start anchor, ordered subject motion, camera behavior, timing, and end report; add performance change and environment/audio only when this shot actually carries them. |
 | VID-03 | structural_invariant | Choose image-to-video only when the matching storyboard's reference set is complete, declares readable REF inputs, and is copied unchanged. No REF is not by itself consent to text-to-video: first discover and bind matching real project images; preserve any verified partial bindings, but if required images remain missing, report them and stop before the final motion document. Choose text-to-video only after the creator explicitly selects it, and carry a non-empty static visual anchor in the copyable text. Only image-to-video may omit appearance/composition already carried by its real reference frame. |
 | VID-04 | structural_invariant | Explicit segment timing sums exactly to its shot's accepted duration—neither exceeding it nor leaving an unallocated remainder. |

--- a/skills/short-drama/scripts/creator_markdown_check.py
+++ b/skills/short-drama/scripts/creator_markdown_check.py
@@ -870,6 +870,17 @@ def _check_language_designators(
             )
 
 
+def _declared_seconds(value: str) -> Optional[float]:
+    """The number of seconds a 时长 field declares, however it is spelled.
+
+    `4s`, `4 秒` and `4秒` are the same duration. Returning None for anything
+    else keeps an unparseable value out of the comparison instead of turning a
+    formatting difference into a false duration conflict.
+    """
+    match = re.search(r"(\d+(?:\.\d+)?)", value or "")
+    return float(match.group(1)) if match else None
+
+
 def _check_continuity_locks(
     locks: list[ContinuityLock],
     *,
@@ -1122,9 +1133,11 @@ def validate_episode(episode: Path, project_root: Optional[Path] = None) -> list
         errors.append("视频提示词.md: 没有 MOTION 条目")
 
     motion_by_shot: dict[str, tuple[str, str, Optional[str]]] = {}
+    motion_duration: dict[str, str] = {}
     for motion_id, body in motions.items():
         fields = _fields(body, owner=motion_id, errors=errors)
         shot_id = _plain(fields.get("分镜", ""))
+        motion_duration[shot_id] = _plain(fields.get("时长", ""))
         copyable_prompt = _copyable_prompt(body)
         if not shot_id:
             errors.append(f"{motion_id}: 缺少分镜字段")
@@ -1145,6 +1158,20 @@ def validate_episode(episode: Path, project_root: Optional[Path] = None) -> list
         claimed_scenes.update(
             _shot_sources(fields.get("来源", ""), shot_id, scenes, errors)
         )
+        shot_seconds = _declared_seconds(_plain(fields.get("时长", "")))
+        motion_seconds = _declared_seconds(motion_duration.get(shot_id, ""))
+        if (
+            shot_seconds is not None
+            and motion_seconds is not None
+            and shot_seconds != motion_seconds
+        ):
+            # 时长 is the value actually sent to the execution end and the term
+            # VID-04/VID-13 arithmetic is built on. A downstream copy that drifts
+            # from its accepted upstream is invisible in every other check.
+            errors.append(
+                f"{shot_id}: 分镜时长 {shot_seconds:g} 秒与视频提示词 "
+                f"{motion_seconds:g} 秒不一致；视频提示词只能原样照抄已接受的镜头时长"
+            )
         image_value = fields.get("图片提示词项", "")
         if not image_value:
             errors.append(f"{shot_id}: 缺少图片提示词项字段")

--- a/tests/test_creator_first_golden.py
+++ b/tests/test_creator_first_golden.py
@@ -423,6 +423,38 @@ class CreatorFirstGoldenTests(unittest.TestCase):
         self.assertIn("不写最终《视频提示词.md》", video_skill)
         self.assertIn("该字段只写这两个精确值", video_skill)
 
+    def test_validator_catches_a_motion_duration_that_drifts_from_its_shot(self) -> None:
+        """时长 is what reaches the generator; a stale copy must not pass silently.
+
+        Every other cross-document check compares text. Duration is a number the
+        execution end acts on and VID-04/VID-13 arithmetic is built from, so a
+        视频提示词 that still carries a superseded shot length is a real defect
+        even though the document parses and every string still matches.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            episode = project / "剧集/EP001"
+            shutil.copytree(EPISODE, episode)
+            self.assertEqual(
+                creator_markdown_check.validate_episode(episode, project),
+                [],
+                "fixture must start clean",
+            )
+            video = episode / "视频提示词.md"
+            document = video.read_text(encoding="utf-8")
+            original = re.search(r"- 时长：(\S+)", document)
+            self.assertIsNotNone(original, "视频提示词 must declare a duration")
+            video.write_text(
+                document.replace(original.group(0), "- 时长：99 秒", 1),
+                encoding="utf-8",
+            )
+
+            errors = creator_markdown_check.validate_episode(episode, project)
+            self.assertTrue(
+                any("与视频提示词" in error and "不一致" in error for error in errors),
+                errors,
+            )
+
     def test_validator_blocks_pending_or_implicit_text_fallback(self) -> None:
         for label, replacement in {
             "pending references": "无（待补参考图：江晨身份、办公室地理）。",


### PR DESCRIPTION
实跑《让你管账号》时真实踩到的静默缺陷。

## 现象

按导演评审重写 SC003 分镜后，八镜时长从 4/4/5/5/5/5/4/5 改成 4/4/4/4/4/4/4/7。此时 `视频提示词.md` 还停在旧值——**012–015 是 5s 对 4s、017 是 5s 对 7s**，而 `creator_markdown_check.py` 返回 `OK`。

构造最小用例确认：

```
视频提示词 - 时长：99 秒
分镜       - 时长：4s
→ OK
```

## 为什么这条要紧

`时长` 与其他跨文档字段不同：

- 它是**唯一真正送进生成端**的那个数——写错就是拿错误的秒数去生成；
- `VID-04`（分段求和必须等于镜头时长）与 `VID-13`（容器时长 = 成员之和）的算术全部建立在它之上；
- 其他跨文档检查比的是**文本**（引文溯源、锁面、画面代称），文本不一致人眼还能看出来；数字不一致，两份文档各自都合法、都解析得动、每个字符串都对得上。

也就是说：**上游改了时长而下游没跟上，是这套流程里唯一一种完全没有信号的漂移。**

## 改法

校验器本来就同时解析 `分镜.md` 与 `视频提示词.md`，把 MOTION 声明的时长收集起来、在既有的逐镜循环里比一次即可。

- 数值容忍 `4s` / `4 秒` / `4秒` 三种写法（同一个时长的不同拼法不该报冲突）；
- 解析不出数字的值不参与比较，避免把格式问题变成假的时长冲突。

同时把这条写进 `VID-01`（它本来就规定「运动只能读、不能改写镜头时长」，现在补上这条是可机械检查的）。

## 测试

新增行为测试：金样例先断言干净，改一处时长后必须报错。不是断言某句文案存在。

546 → 547 项测试，546 通过；唯一失败是 `test_dashboard_browser` 缺 Playwright 二进制，未改动的树上同样失败。

🤖 Generated with [Claude Code](https://claude.com/claude-code)