### PR TITLE
fix: 发版前 review 找出的六处缺陷

### DIFF
--- a/skills/short-drama-edit/scripts/edit_tool.py
+++ b/skills/short-drama-edit/scripts/edit_tool.py
@@ -77,7 +77,14 @@ SUBTITLE_CUE = re.compile(r"^\s*([0-9.]+)\s*[-–~]\s*([0-9.]+)\s+(.+?)\s*$")
 # does not state is a correction no reviewer can see.
 PICTURE_KEYS = {"亮度": "brightness", "饱和": "saturation", "色温": "warmth"}
 PICTURE_TERM = re.compile(r"(亮度|饱和|色温)\s*([+-]?[0-9]*\.?[0-9]+)")
-PICTURE_LIMITS = {"brightness": 0.25, "saturation": 2.0, "warmth": 30.0}
+# Each term's real range, not a symmetric magnitude: ffmpeg's `eq` takes
+# saturation in 0..3, so a negative value that passes an abs() bound is accepted
+# by the document and then rejected by the renderer, halfway through a render.
+PICTURE_LIMITS = {
+    "brightness": (-0.25, 0.25),
+    "saturation": (0.0, 2.0),
+    "warmth": (-30.0, 30.0),
+}
 TOLERANCE = 0.005
 
 
@@ -219,10 +226,11 @@ def _finish_cut(pending: dict[str, Any]) -> Cut:
             for label, value in PICTURE_TERM.findall(text):
                 key = PICTURE_KEYS[label]
                 number = float(value)
-                if abs(number) > PICTURE_LIMITS[key]:
+                low, high = PICTURE_LIMITS[key]
+                if not low <= number <= high:
                     raise EditError(
                         f"{CUT_LIST_NAME}:{where}: {cut_id} 的画面「{label}」超出允许范围"
-                        f"（±{PICTURE_LIMITS[key]}）：{number}"
+                        f"（{low:g} 到 {high:g}）：{number}"
                     )
                 picture[key] = number
             if not picture:
@@ -804,10 +812,22 @@ def _build_ass(
         "Effect, Text\n"
     )
     lines = [
-        f"Dialogue: 0,{_ass_time(start)},{_ass_time(end)},正片,,0,0,0,,{text}"
+        f"Dialogue: 0,{_ass_time(start)},{_ass_time(end)},正片,,0,0,0,,{_ass_text(text)}"
         for start, end, text in cues
     ]
     return header + "\n".join(lines) + "\n"
+
+
+def _ass_text(text: str) -> str:
+    """Escape a line so ASS renders its characters instead of reading them.
+
+    `{`…`}` is an override block in ASS and `\` starts an escape, so a quoted
+    line that happens to contain either would lose characters on screen with no
+    error anywhere — and EDT-05 exists precisely to keep the burned text equal
+    to the screenplay's, character for character.
+    """
+
+    return text.replace("\\", "\\\\").replace("{", "\\{").replace("}", "\\}")
 
 
 def _ass_time(seconds: float) -> str:

--- a/skills/short-drama-edit/scripts/selftest.py
+++ b/skills/short-drama-edit/scripts/selftest.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from edit_tool import (  # noqa: E402
     EditError,
+    _ass_text,
     _build_ass,
     _shot_match_filter,
     _subtitle_cues,
@@ -164,6 +165,18 @@ def check_shot_match() -> None:
         require("brightness=0.06" in chain, f"亮度没进滤镜链: {chain}")
         require("colorbalance" in chain and "rm=-0.06" in chain, f"色温没进滤镜链: {chain}")
 
+        # ffmpeg 的 eq 只接受 0..3 的饱和度；负数在文档里通过、渲染时才炸。
+        negative = CUT_LIST.replace(
+            "- 声音：保留原声\n- 字幕：无",
+            "- 声音：保留原声\n- 画面：饱和 -1.5\n- 字幕：无", 1)
+        (episode / "剪辑单.md").write_text(negative, encoding="utf-8")
+        try:
+            parse_cut_list(episode / "剪辑单.md")
+        except EditError as error:
+            require("超出允许范围" in str(error), f"负饱和度报错不对: {error}")
+        else:
+            raise AssertionError("饱和 -1.5 应当被拒绝——ffmpeg 不接受负饱和度")
+
         # 超出范围是重新调色，不是接镜，必须挡住。
         wild = CUT_LIST.replace(
             "- 声音：保留原声\n- 字幕：无",
@@ -258,6 +271,28 @@ def check_multi_subtitle() -> None:
             raise AssertionError("多句字幕缺时间应当被拒绝")
 
 
+def check_ass_escaping() -> None:
+    """A quoted line keeps every character it had in 剧本.md.
+
+    `{`…`}` is an override block in ASS: unescaped, libass drops the braces and
+    everything between them, on screen, with no error anywhere. EDT-05 exists to
+    keep the burned text equal to the screenplay's character for character, so a
+    silent swallow breaks the one rule this stage is a structural invariant about.
+    """
+
+    line = "他念出来：{姓名}，请签字。"
+    escaped = _ass_text(line)
+    require("\\{" in escaped and "\\}" in escaped, f"花括号没有转义: {escaped}")
+    require("姓名" in escaped, "转义把字弄丢了")
+    ass = _build_ass([(1.0, 2.0, line)], 1080, 1920)
+    dialogue = [row for row in ass.splitlines() if row.startswith("Dialogue")][0]
+    require(dialogue.endswith(escaped), f"Dialogue 行没有用转义后的正文: {dialogue}")
+    require(
+        _ass_text("反斜杠 \\N 不是换行").count("\\\\") == 1,
+        "反斜杠没有转义，\\N 会被当成换行",
+    )
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as scratch:
         root = Path(scratch)
@@ -324,6 +359,7 @@ def main() -> int:
     check_subtitle_geometry()
     check_subtitle_timing()
     check_shot_match()
+    check_ass_escaping()
     check_multi_subtitle()
     print("short-drama-edit self-tests passed")
     return 0

--- a/skills/short-drama-produce/scripts/production_tool.py
+++ b/skills/short-drama-produce/scripts/production_tool.py
@@ -1674,6 +1674,13 @@ def run_job(root: Path, *, job_id: str, adapter_config: Path) -> dict[str, Any]:
                             "sha256": digest,
                         }
                     )
+                if _run_status(root, job_id, run_id) == "succeeded":
+                    # `collect` reached the same provider task first and its
+                    # outputs are already in the project. Leave that record
+                    # alone rather than replacing a collected attempt.
+                    raise RuntimeError(
+                        "这次尝试已经被 collect 取回并标为成功；本次运行不覆盖它"
+                    )
                 run["status"] = "succeeded"
                 run["finished_at"] = utc_now()
                 run["outputs"] = written
@@ -1703,6 +1710,16 @@ def run_job(root: Path, *, job_id: str, adapter_config: Path) -> dict[str, Any]:
         "state": "succeeded",
         "outputs": run["outputs"],
     }
+
+
+def _run_status(root: Path, job_id: str, run_id: str) -> str | None:
+    """The status one attempt currently has on disk, re-read rather than cached."""
+
+    for run in _read_run_history(root, job_id):
+        if str(run.get("run_id")) == run_id:
+            status = run.get("status")
+            return status if isinstance(status, str) else None
+    return None
 
 
 def collect_job(root: Path, *, job_id: str, adapter_config: Path) -> dict[str, Any]:
@@ -1751,6 +1768,18 @@ def collect_job(root: Path, *, job_id: str, adapter_config: Path) -> dict[str, A
         adapter_outputs = _validate_adapter_outputs(job, response, output_root)
         written: list[dict[str, Any]] = []
         with _project_lock(root):
+            # The adapter call happens outside the lock, and `run_job` may have
+            # been polling the very same provider task the whole time — an
+            # attempt whose adapter is still alive looks exactly like one whose
+            # adapter died, because both sit at status `running`. Re-read the
+            # record before writing: if that attempt finished on its own, its
+            # outputs are already in the project and overwriting them here would
+            # race two writers onto the same bytes and drop its record.
+            if _run_status(root, job_id, str(run["run_id"])) == "succeeded":
+                raise RuntimeError(
+                    "这次尝试在取回期间已经自己完成了，产物已经落进项目；"
+                    "没有覆盖它——先看 status，确认无误就不需要再做别的"
+                )
             for target_name, source in adapter_outputs:
                 target = _project_file(root, target_name, create_parent=True)
                 digest, size = _copy_output(
@@ -1950,6 +1979,11 @@ def audit_project(root: Path) -> dict[str, Any]:
                     "run_id": run["run_id"],
                     "provider_job_id": handle,
                     "action": "collect_before_retry",
+                    # A live attempt and a dead one both sit at `running`, so
+                    # this finding cannot tell them apart. Collecting is still
+                    # the right first move — it is the only one that costs
+                    # nothing — and it refuses safely if the attempt finished.
+                    "note": "status 为 running 时它可能仍在正常轮询；collect 会先确认再写",
                 }
             )
         if running:

--- a/skills/short-drama/assets/dashboard/app.js
+++ b/skills/short-drama/assets/dashboard/app.js
@@ -729,12 +729,17 @@ function renderMarkdown(content) {
       }
       continue;
     }
-    if (/^\s*```/.test(line)) { closeList(); closeQuote(); fence = []; continue; }
+    // Before the fence test: a ``` line inside a comment is commented out, and
+    // letting it open a fence would render the hidden sample as a code block.
     if (comment !== null) {
-      comment.push(line);
-      if (line.includes("-->")) comment = null;
-      continue;
+      const closeAt = line.indexOf("-->");
+      if (closeAt === -1) { comment.push(line); continue; }
+      comment = null;
+      // Text after the terminator is body text in both Markdown and HTML.
+      line = line.slice(closeAt + 3);
+      if (!line.trim()) { closeQuote(); continue; }
     }
+    if (/^\s*```/.test(line)) { closeList(); closeQuote(); fence = []; continue; }
     // Strip closed comments where they sit, so `正文 <!-- 注 -->` keeps its text.
     // One pass is not enough: removing the inner comment of `<!<!-- x -->-- y -->`
     // joins its neighbours back into a new `<!--`, so repeat until stable.
@@ -743,12 +748,16 @@ function renderMarkdown(content) {
       previous = stripped;
       stripped = stripped.replace(/<!--[\s\S]*?-->/g, "");
     }
-    if (stripped.indexOf("<!--") !== -1) {
+    const openAt = stripped.indexOf("<!--");
+    if (openAt !== -1) {
       closeList();
       closeQuote();
-      const before = stripped.slice(0, stripped.indexOf("<!--"));
+      const before = stripped.slice(0, openAt);
       if (before.trim()) paragraph(before);
-      comment = [line];
+      // Only the part that is actually still open — keeping the whole original
+      // line would re-emit the prefix already rendered above if the block never
+      // closes.
+      comment = [stripped.slice(openAt)];
       continue;
     }
     if (stripped !== line) {

--- a/tests/test_confirmed_production.py
+++ b/tests/test_confirmed_production.py
@@ -960,6 +960,52 @@ class ConfirmedProductionTests(unittest.TestCase):
                 [],
             )
 
+    def test_collect_does_not_overwrite_an_attempt_that_finished_on_its_own(self) -> None:
+        """A live attempt and a dead one both sit at `running`.
+
+        `audit` cannot tell them apart, so it reports a healthy in-flight
+        attempt as an orphan too. Following that advice must not let two writers
+        race onto the same output bytes and the same run record — collecting
+        re-reads the record before writing and backs off if the attempt
+        completed while the adapter was being called.
+        """
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = self.make_project(directory)
+            job = self.write_job(root)
+            self.prepare_and_confirm(root, job)
+            interrupted = self.adapter_config(directory, submit_then_fail=True)
+            with self.assertRaises(production_tool.AdapterError):
+                production_tool.run_job(
+                    root, job_id="EP001-SHOT001", adapter_config=interrupted
+                )
+
+            # The original attempt finishes *while the collect adapter is being
+            # called* — the window `collect_job` leaves open on purpose, because
+            # the adapter must not hold the project lock for minutes.
+            original = production_tool._run_adapter
+
+            def finish_then_answer(command, timeout, payload, adapter_root):
+                history = production_tool._read_run_history(root, "EP001-SHOT001")
+                finished = dict(history[-1])
+                finished["status"] = "succeeded"
+                finished["outputs"] = []
+                production_tool._write_run(root, "EP001-SHOT001", finished)
+                return original(command, timeout, payload, adapter_root)
+
+            production_tool._run_adapter = finish_then_answer
+            self.addCleanup(setattr, production_tool, "_run_adapter", original)
+
+            with self.assertRaisesRegex(RuntimeError, "已经自己完成"):
+                production_tool.collect_job(
+                    root,
+                    job_id="EP001-SHOT001",
+                    adapter_config=self.adapter_config(directory),
+                )
+            after = production_tool._read_run_history(root, "EP001-SHOT001")[-1]
+            self.assertEqual(after["status"], "succeeded")
+            self.assertNotIn("collected", after)
+
     def test_collect_refuses_when_no_attempt_carries_a_provider_job(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = self.make_project(directory)

--- a/tests/test_dashboard_browser.py
+++ b/tests/test_dashboard_browser.py
@@ -37,6 +37,9 @@ class DashboardBrowserTests(unittest.TestCase):
             "第二段正文 <!-- 行内备注 --> 后半句。\n\n"
             "```md\n<!-- 代码块里的注释要保留 -->\n```\n\n"
             "嵌套 <!<!-- 内层 -->-- 外层 --> 之后。\n\n"
+            "<!-- 跨行备注\n     第二行 --> 终止符后面的正文。\n\n"
+            "<!-- 注释里的围栏\n```md\n围栏里的内容不该出现\n```\n-->\n\n"
+            "围栏之后的正文。\n\n"
             "<!-- 这条没有闭合\n还有一行\n",
             encoding="utf-8",
         )
@@ -132,9 +135,20 @@ class DashboardBrowserTests(unittest.TestCase):
         self.assertNotIn("外层", body)
         # A fenced block is copied verbatim, comments included.
         self.assertIn("代码块里的注释要保留", body)
+        # Text after the terminator on a closing line is body text.
+        self.assertIn("终止符后面的正文。", body)
+        self.assertNotIn("跨行备注", body)
+        self.assertNotIn("第二行", body)
+        # A fence inside a comment is commented out, not a code block.
+        self.assertNotIn("围栏里的内容不该出现", body)
+        self.assertNotIn("注释里的围栏", body)
+        self.assertIn("围栏之后的正文。", body)
         # Unterminated: preserved, not swallowed along with the rest.
         self.assertIn("这条没有闭合", body)
         self.assertIn("还有一行", body)
+        # ...and preserved once. A line that closes one comment and opens an
+        # unterminated one must not render its prefix twice.
+        self.assertEqual(body.count("嵌套"), 1)
 
     def test_long_project_title_never_creates_horizontal_page_scroll(self) -> None:
         for width in (861, 860, 620, 390, 360):


### PR DESCRIPTION
v0.7.0 发版前对 `v0.6.6..main` 做了一遍逐 hunk 复查。六处都是真会出错的，不是风格问题。

## 1. collect 与仍在运行的那次尝试会撞车

适配器在**第一次轮询之前**就写句柄（那正是它存在的意义），所以「还活着的尝试」和「已经死掉的尝试」在记录上长得一模一样——都停在 `running`。

`audit` 因此会把正常在跑的那条也报成 `orphaned_provider_job`，`action: collect_before_retry`。照它说的做，两个写入方会同时往**同一个产物路径**和**同一条 run 记录**上写：`run_job` 在 1599 行用 `_active_run` 挡住了这种并发，`collect_job` 没有对应的守卫，而且适配器调用期间是不持锁的。

改法是对 run 记录做 compare-and-set：适配器返回之后重新读一遍，那次尝试要是已经自己完成，就不覆盖它的产物与记录，直接报出来。反向也一样——`run_job` 写回之前也确认没有被 collect 抢先。

没有改成「有活跃尝试就拒绝 collect」：崩掉的尝试同样停在 `running`，那样会把主要用例挡死。

## 2. 负的饱和度在文档里通过、渲染时才炸

范围检查用的是对称的 `abs(number) > 2.0`，而 ffmpeg 的 `eq` 只接受 **0..3** 的饱和度。

`- 画面：饱和 -1.5` 通过 `check`，然后在前面几段都已经重编码之后，`render` 才抛出一段 ffmpeg 原始报错。文档层面就不成立的值，该在 `check` 拦住。改成每一项各自的真实上下界。

## 3–5. 创作台的注释处理有三处

| | 症状 |
|---|---|
| 跨行注释的收尾行整行被吞 | `… --> 江晨坐在剪辑台前。` 里的正文在阅读栏凭空消失 |
| 围栏判断在注释判断之前 | 注释里的 ` ``` ` 真的开了围栏，把本该藏起来的示例当代码块画出来 |
| 一行既闭合又开启 | 前缀被渲染两次 |

三条都改了：注释判断移到围栏之前；收尾行保留终止符之后的正文；未闭合时只保存真正还开着的那一段，而不是整行原文。

## 6. ASS 正文没有转义

`{`…`}` 在 ASS 里是覆盖块，`\` 是转义符。一句带花括号的台词会在屏幕上**丢字**，而且没有任何一处报错——而 `EDT-05` 正是为了「烧进去的字与剧本逐字相同」而存在的 `structural_invariant`。

## 验证

六条各配咬人的测试。把三个源文件换回 `main` 的版本重跑：`test_confirmed_production` 与 `test_dashboard_browser` 各红一条，`short-drama-edit` 的 selftest 直接 ImportError。换回来全量 560 条通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)