### PR TITLE
docs(readme): skill count is eleven since v0.7.0 added short-drama-edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![License](https://img.shields.io/github/license/zenstory-ai/drama-skills)](LICENSE)
 
-面向编剧、漫剧工作室和编导的 AI 短剧创作工作流。十个技能把一个点子或一部长篇材料，
+面向编剧、漫剧工作室和编导的 AI 短剧创作工作流。十一个技能把一个点子或一部长篇材料，
 一路做成分集剧本、资产设定、图片提示词、分镜关键帧和视频提示词，
 用清晰的所有权与连续性衔接。适配 Claude Code、Codex 和其他
 支持 Agent Skill 规范的运行环境。
@@ -103,10 +103,10 @@ done
 
 示例都在 [examples/](examples/)。creator-first 的公开完整样例是
 [《让你管账号》EP001](examples/creator-first/EP001/)；其余目录仅作为仓库维护和校验器回归夹具。
-想把十个技能按漫剧产线从头串一遍（每步命令、产物与卡点），看
+想把十一个技能按漫剧产线从头串一遍（每步命令、产物与卡点），看
 [漫剧创作全流程指引](docs/comic-drama-workflow.md)。
 
-## 十个技能
+## 十一个技能
 
 ```mermaid
 flowchart LR

--- a/README_EN.md
+++ b/README_EN.md
@@ -8,7 +8,7 @@
 [![License](https://img.shields.io/github/license/zenstory-ai/drama-skills)](LICENSE)
 
 An AI short-drama creation suite for screenwriters, motion-comic studios, and
-directors. Ten skills take an idea or a long-form source all the way to episode
+directors. Eleven skills take an idea or a long-form source all the way to episode
 scripts, asset decisions, image prompts, storyboard keyframes, and video prompts —
 carrying clear ownership and
 continuity through the entire chain. Works with Claude Code, Codex, and other
@@ -119,11 +119,11 @@ Samples live in [examples/](examples/). The public creator-first sample is
 [*Let You Run the Account*, EP001](examples/creator-first/EP001/). Other example
 directories are repository-maintenance and validator-regression fixtures rather than
 instructions for the current workflow.
-To walk the ten skills as one comic-drama production line, with per-step commands,
+To walk the eleven skills as one comic-drama production line, with per-step commands,
 outputs, and common pitfalls, see the
 [comic-drama workflow guide](docs/comic-drama-workflow.md) (Chinese).
 
-## The ten skills
+## The eleven skills
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
The README heading and intro still say ten skills; the table under it lists eleven and `skills/` contains eleven (v0.7.0 added `short-drama-edit`). Updates the three mentions in each README. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZW7Q9fSdjvVSzyrWxxTa2