### PR TITLE
docs(readme): link the project page on zenstory.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # Drama Skills
 
+> 项目页：<https://zenstory.ai/drama-skills> · ZenStory AI 全部项目：<https://zenstory.ai/projects>
+
 [![CI](https://github.com/zenstory-ai/drama-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/zenstory-ai/drama-skills/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/zenstory-ai/drama-skills)](https://github.com/zenstory-ai/drama-skills/releases/latest)
 [![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)

--- a/README_EN.md
+++ b/README_EN.md
@@ -2,6 +2,8 @@
 
 # Drama Skills
 
+> Project page: <https://zenstory.ai/drama-skills> · All ZenStory AI projects: <https://zenstory.ai/projects>
+
 [![CI](https://github.com/zenstory-ai/drama-skills/actions/workflows/ci.yml/badge.svg)](https://github.com/zenstory-ai/drama-skills/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/zenstory-ai/drama-skills)](https://github.com/zenstory-ai/drama-skills/releases/latest)
 [![Python](https://img.shields.io/badge/Python-3.9%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)


### PR DESCRIPTION
One line under the title pointing at this project's page on the organization site (https://zenstory.ai/…) and at the six-project overview (https://zenstory.ai/projects). Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZW7Q9fSdjvVSzyrWxxTa2