### PR TITLE
docs(readme): point ZenStory workbench to app subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,4 +189,4 @@ macOS、Linux、WSL 与 Windows 原生都可运行。创作台以 `--detach` 独
 | [novel-to-game](https://github.com/zenstory-ai/novel-to-game) | 把小说改编成可玩游戏的 agent skills |
 | [video-recap-skills](https://github.com/zenstory-ai/video-recap-skills) | 把任意视频剪成中文解说视频，支持剪映草稿导出 |
 | [oh-story-dsh](https://github.com/zenstory-ai/oh-story-dsh) | DeepSeek Harness 插件，封装 Oh Story 与 Drama Skills 工作流 |
-| [zenstory](https://github.com/zenstory-ai/zenstory) | 对话即创作的 AI 小说写作工作台（zenstory.ai） |
+| [zenstory](https://github.com/zenstory-ai/zenstory) | 对话即创作的 AI 小说写作工作台（[app.zenstory.ai](https://app.zenstory.ai)） |

--- a/README_EN.md
+++ b/README_EN.md
@@ -205,4 +205,4 @@ This project is maintained by [ZenStory AI](https://zenstory.ai) — open-source
 | [novel-to-game](https://github.com/zenstory-ai/novel-to-game) | Agent skills that turn novels into playable games |
 | [video-recap-skills](https://github.com/zenstory-ai/video-recap-skills) | Clip any video into a narrated Chinese recap, with CapCut draft export |
 | [oh-story-dsh](https://github.com/zenstory-ai/oh-story-dsh) | DeepSeek Harness plugin wrapping the Oh Story and Drama Skills workflows |
-| [zenstory](https://github.com/zenstory-ai/zenstory) | Chat-to-create AI novel-writing workbench (zenstory.ai) |
+| [zenstory](https://github.com/zenstory-ai/zenstory) | Chat-to-create AI novel-writing workbench ([app.zenstory.ai](https://app.zenstory.ai)) |


### PR DESCRIPTION
## Summary
- link the ZenStory writing workbench to `https://app.zenstory.ai` in both README languages
- keep `https://zenstory.ai` as the organization and project-site domain

This reflects the completed domain migration; no runtime behavior or external project is changed.

## Validation
- `python3 -B -m unittest discover -s tests -v` (571 tests passed)
- `git diff --check`